### PR TITLE
Optimize metadata saving by caching

### DIFF
--- a/dataladmetadatamodel/mapper/gitmapper/gitbackend/subprocess.py
+++ b/dataladmetadatamodel/mapper/gitmapper/gitbackend/subprocess.py
@@ -128,8 +128,13 @@ def git_save_str(repo_dir, content: str) -> str:
 
 
 def git_save_file_list(repo_dir, file_list: List[str]) -> List[str]:
-    cmd_line = git_command_line(repo_dir, "hash-object", ["-w", "--no-filters"] + file_list)
-    return checked_execute(cmd_line)[0]
+    cmd_line = git_command_line(
+        repo_dir,
+        "hash-object",
+        ["-w", "--no-filters", "--stdin-paths"])
+    return checked_execute(
+        cmd_line,
+        stdin_content="\n".join(file_list))[0]
 
 
 def git_save_json(repo_dir, json_object: Union[Dict, List]) -> str:

--- a/dataladmetadatamodel/mapper/gitmapper/gitbackend/subprocess.py
+++ b/dataladmetadatamodel/mapper/gitmapper/gitbackend/subprocess.py
@@ -127,6 +127,11 @@ def git_save_str(repo_dir, content: str) -> str:
     return checked_execute(cmd_line, stdin_content=content)[0][0]
 
 
+def git_save_file_list(repo_dir, file_list: List[str]) -> List[str]:
+    cmd_line = git_command_line(repo_dir, "hash-object", ["-w", "--no-filters"] + file_list)
+    return checked_execute(cmd_line)[0]
+
+
 def git_save_json(repo_dir, json_object: Union[Dict, List]) -> str:
     return git_save_str(repo_dir, json.dumps(json_object))
 

--- a/dataladmetadatamodel/mapper/gitmapper/gitblobcache.py
+++ b/dataladmetadatamodel/mapper/gitmapper/gitblobcache.py
@@ -1,0 +1,88 @@
+import hashlib
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import (
+    Dict,
+    List,
+    Union,
+)
+
+from .gitbackend.subprocess import git_save_file_list
+
+
+def hash_blob(blob: Union[str, bytes]) -> str:
+    if isinstance(blob, str):
+        blob = bytearray(blob.encode())
+    else:
+        blob = bytearray(blob)
+
+    object_to_hash = f"blob {len(blob)}".encode() + b"\x00" + blob
+    return hashlib.sha1(object_to_hash).hexdigest()
+
+
+class GitBlobCache:
+    def __init__(self,
+                 realm: str,
+                 maxsize: int = 2000):
+
+        assert isinstance(realm, str)
+
+        self.realm = realm
+        self.maxsize = maxsize
+        self.cached_objects: List[Union[str, bytes]] = list()
+        self.flushed_objects: Dict[Union[str, bytes], str] = dict()
+        self.temporary_directory = TemporaryDirectory()
+        self.temp_dir_path = Path(self.temporary_directory.name)
+
+    def __del__(self):
+        if len(self.cached_objects) > 0:
+            raise RuntimeError("deleting a non-flushed JSON object cache")
+        self.temporary_directory.cleanup()
+
+    def cache_blob(self,
+                   realm: str,
+                   blob: Union[str, bytes]):
+
+        assert realm == self.realm, \
+            "realm of cached object and realm of cache instance differ"
+
+        if len(self.cached_objects) == self.maxsize:
+            self.flush()
+        expected_hash = hash_blob(blob)
+        self.cached_objects.append((blob, expected_hash))
+        return expected_hash
+
+    def flush(self):
+        """
+        Write all cached objects to a git repository,
+        associate the objects with their hash in
+        self.cached_objects.
+
+        Writing is done by creating files in a
+        temporary directory and calling git hash-object
+        with the list of files.
+
+        :return: None
+        """
+        def check_hash(hash: str, expected_hash: str):
+            assert hash == expected_hash
+
+        file_list = []
+        for index, (blob, expected_hash) in enumerate(self.cached_objects):
+            temp_file_path = self.temp_dir_path / str(index)
+            with temp_file_path.open("tw") as f:
+                f.write(blob)
+            file_list.append(str(temp_file_path))
+
+        hash_values = git_save_file_list(self.realm, file_list)
+        assert len(hash_values) == len(file_list), \
+            f"hash value list length ({len(hash_values)}) and file list length " \
+            f"({len(file_list)}) differ.\n{hash_values}\n{file_list}"
+
+        hash_dict = {
+            blob: hash_values[index]
+            for index, (blob, expected_hash) in enumerate(self.cached_objects)
+            if check_hash(hash_values[index], expected_hash)
+        }
+        self.flushed_objects.update(hash_dict)
+        self.cached_objects = []

--- a/dataladmetadatamodel/mapper/gitmapper/gitblobcache.py
+++ b/dataladmetadatamodel/mapper/gitmapper/gitblobcache.py
@@ -25,14 +25,16 @@ class GitBlobCache:
                  realm: str,
                  maxsize: int = 2000):
 
-        assert isinstance(realm, str)
-
         self.realm = realm
         self.maxsize = maxsize
         self.cached_objects: List[Union[str, bytes]] = list()
         self.flushed_objects: Dict[Union[str, bytes], str] = dict()
         self.temporary_directory = TemporaryDirectory()
         self.temp_dir_path = Path(self.temporary_directory.name)
+
+        # Assert after member initialisation, so in case of an
+        # exception the destructor does still work
+        assert isinstance(realm, str)
 
     def __del__(self):
         if len(self.cached_objects) > 0:

--- a/dataladmetadatamodel/mapper/gitmapper/metadatamapper.py
+++ b/dataladmetadatamodel/mapper/gitmapper/metadatamapper.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 from dataladmetadatamodel.mapper.gitmapper.objectreference import (
     GitReference,
     add_blob_reference,
@@ -9,8 +11,30 @@ from dataladmetadatamodel.mapper.gitmapper.gitbackend.subprocess import (
 from dataladmetadatamodel.mapper.mapper import Mapper
 from dataladmetadatamodel.mapper.reference import Reference
 
+from .gitblobcache import GitBlobCache
+
 
 class MetadataGitMapper(Mapper):
+
+    metadata_caches: Dict[str, GitBlobCache] = dict()
+
+    @classmethod
+    def get_cache(cls, realm):
+        return cls.metadata_caches.get(realm, None)
+
+    @classmethod
+    def cache_realm(cls, realm):
+        if cls.get_cache(realm) is not None:
+            raise RuntimeError(f"already caching realm: {realm}")
+        cls.metadata_caches[realm] = GitBlobCache(realm)
+
+    @classmethod
+    def flush_realm(cls, realm):
+        cache = cls.get_cache(realm)
+        if cache is None:
+            raise RuntimeError(f"realm is not cached: {realm}")
+        cache.flush()
+        del cls.metadata_caches[realm]
 
     def map_in_impl(self,
                     metadata: "Metadata",
@@ -36,6 +60,17 @@ class MetadataGitMapper(Mapper):
         from dataladmetadatamodel.metadata import Metadata
         assert isinstance(metadata, Metadata)
 
+        cache = self.get_cache(realm)
+        if cache is None:
+            return self.map_out_impl_immediate(metadata, realm, force_write)
+        else:
+            return self.map_out_impl_cached(cache, metadata, realm)
+
+    def map_out_impl_immediate(self,
+                               metadata: "Metadata",
+                               realm: str,
+                               force_write: bool) -> Reference:
+
         # Save metadata object and add it to the
         # blob-references. That is necessary because
         # metadata blobs are only referenced in
@@ -45,17 +80,40 @@ class MetadataGitMapper(Mapper):
         metadata_blob_location = git_save_str(realm, metadata.to_json())
         add_blob_reference(GitReference.BLOBS, metadata_blob_location)
 
-        # save reference
+        # Save reference. NB we don't have to save
+        # metadata_reference_blob_location to the
+        # reference objects because they will be
+        # reachable by a git tree entry.
         metadata_reference_blob_location = git_save_str(
             realm,
             Reference(
                 "Metadata",
                 metadata_blob_location).to_json_str())
 
-        # Return reference to reference, also it specifies
+        # Return reference to reference, although it specifies
         # the class Metadata, it points actually to a
         # persisted Reference object. But this is only known
         # internally in this mapper.
+        return Reference(
+            "Metadata",
+            metadata_reference_blob_location)
+
+    def map_out_impl_cached(self,
+                            cache: GitBlobCache,
+                            metadata: "Metadata",
+                            realm: str) -> Reference:
+
+        # Cache metadata, and cache a reference object. the
+        # following code is "cache"-equivalent to the immediate case
+        metadata_blob_location = cache.cache_blob(realm, metadata.to_json())
+        add_blob_reference(GitReference.BLOBS, metadata_blob_location)
+
+        metadata_reference_blob_location = cache.cache_blob(
+            realm,
+            Reference(
+                "Metadata",
+                metadata_blob_location).to_json_str())
+
         return Reference(
             "Metadata",
             metadata_reference_blob_location)

--- a/dataladmetadatamodel/mapper/gitmapper/tests/test_metadatamapper.py
+++ b/dataladmetadatamodel/mapper/gitmapper/tests/test_metadatamapper.py
@@ -1,15 +1,18 @@
 import json
 import unittest
 from pathlib import Path
+from typing import cast
 from unittest import mock
 
 from .... import version_string
 from ....tests.utils import get_location
+from dataladmetadatamodel.mapper import get_mapper
+from dataladmetadatamodel.mapper.gitmapper.metadatamapper import MetadataGitMapper
+from dataladmetadatamodel.mapper.gitmapper.objectreference import flush_object_references
 from dataladmetadatamodel.metadata import (
     ExtractorConfiguration,
     Metadata
 )
-from dataladmetadatamodel.mapper.gitmapper.objectreference import flush_object_references
 
 
 expected_reference_object = {
@@ -104,6 +107,15 @@ class TestMetadataMapper(unittest.TestCase):
 
             # ensure that the object reference stores are updated
             add_ref.assert_called_once()
+
+    def test_double_cache_detection(self):
+        metadata_mapper: MetadataGitMapper = cast(
+            MetadataGitMapper,
+            get_mapper("Metadata", "git")
+        )
+        metadata_mapper.cache_realm("a")
+        self.assertRaises(RuntimeError, metadata_mapper.cache_realm, "a")
+        self.assertRaises(RuntimeError, metadata_mapper.flush_realm, "err")
 
 
 if __name__ == '__main__':

--- a/dataladmetadatamodel/mapper/gitmapper/tests/test_metadatarootrecordmapper.py
+++ b/dataladmetadatamodel/mapper/gitmapper/tests/test_metadatarootrecordmapper.py
@@ -2,6 +2,7 @@ import unittest
 from unittest import mock
 from uuid import UUID
 
+from dataladmetadatamodel.mapper.gitmapper.gitblobcache import hash_blob
 from dataladmetadatamodel.metadata import Metadata
 from dataladmetadatamodel.metadatapath import MetadataPath
 from dataladmetadatamodel.metadatarootrecord import MetadataRootRecord
@@ -43,15 +44,22 @@ class TestMetadataMapper(unittest.TestCase):
             Metadata(),
             file_tree)
 
-        with mock.patch("dataladmetadatamodel.mapper.gitmapper.metadatarootrecordmapper.git_save_json") as save, \
-             mock.patch("dataladmetadatamodel.mapper.gitmapper.metadatamapper.git_save_str") as str_save, \
-             mock.patch("dataladmetadatamodel.mapper.gitmapper.gitblobcache.git_save_file_list") as file_list_save, \
-             mock.patch("dataladmetadatamodel.mapper.gitmapper.mtreenodemapper.git_save_tree_node") as save_tree_node:
+        with mock.patch("dataladmetadatamodel.mapper.gitmapper."
+                        "metadatarootrecordmapper.git_save_json") as save, \
+             mock.patch("dataladmetadatamodel.mapper.gitmapper."
+                        "metadatamapper.git_save_str") as str_save, \
+             mock.patch("dataladmetadatamodel.mapper.gitmapper."
+                        "gitblobcache.git_save_file_list") as file_list_save, \
+             mock.patch("dataladmetadatamodel.mapper.gitmapper."
+                        "mtreenodemapper.git_save_tree_node") as save_tree_node:
 
             save.configure_mock(return_value=location_0)
             str_save.configure_mock(return_value=location_1)
             save_tree_node.configure_mock(return_value=location_3)
-            file_list_save.side_effect = lambda r, l: l
+            file_list_save.side_effect = lambda r, l: [
+                hash_blob(open(e, "rb").read())
+                for e in l
+            ]
 
             reference = mrr.write_out("/tmp/t1", "git")
             self.assertEqual(reference.location, location_0)

--- a/dataladmetadatamodel/mapper/gitmapper/tests/test_metadatarootrecordmapper.py
+++ b/dataladmetadatamodel/mapper/gitmapper/tests/test_metadatarootrecordmapper.py
@@ -12,11 +12,13 @@ from .... import version_string
 
 uuid_0 = UUID("00000000000000000000000000000000")
 dataset_version = "000000011111222223333"
+
+
 location_0 = "a000000000000000000000000000000000000000"
 location_1 = "a000000000000000000000000000000000000001"
 location_2 = "a000000000000000000000000000000000000002"
 location_3 = "a000000000000000000000000000000000000003"
-
+location_4 = "a000000000000000000000000000000000000004"
 
 default_paths = [
     MetadataPath("a/b/c"),
@@ -43,11 +45,13 @@ class TestMetadataMapper(unittest.TestCase):
 
         with mock.patch("dataladmetadatamodel.mapper.gitmapper.metadatarootrecordmapper.git_save_json") as save, \
              mock.patch("dataladmetadatamodel.mapper.gitmapper.metadatamapper.git_save_str") as str_save, \
+             mock.patch("dataladmetadatamodel.mapper.gitmapper.gitblobcache.git_save_file_list") as file_list_save, \
              mock.patch("dataladmetadatamodel.mapper.gitmapper.mtreenodemapper.git_save_tree_node") as save_tree_node:
 
             save.configure_mock(return_value=location_0)
             str_save.configure_mock(return_value=location_1)
             save_tree_node.configure_mock(return_value=location_3)
+            file_list_save.side_effect = lambda r, l: l
 
             reference = mrr.write_out("/tmp/t1", "git")
             self.assertEqual(reference.location, location_0)

--- a/dataladmetadatamodel/mapper/gitmapper/tests/test_versionlistmapper.py
+++ b/dataladmetadatamodel/mapper/gitmapper/tests/test_versionlistmapper.py
@@ -1,14 +1,15 @@
 import unittest
 from unittest import mock
 
+from dataladmetadatamodel.mapper.gitmapper.gitblobcache import hash_blob
+from dataladmetadatamodel.metadata import Metadata
+from dataladmetadatamodel.metadatapath import MetadataPath
+from dataladmetadatamodel.metadatarootrecord import MetadataRootRecord
 from dataladmetadatamodel.tests.utils import (
     create_file_tree,
     get_location,
     get_uuid,
 )
-from dataladmetadatamodel.metadata import Metadata
-from dataladmetadatamodel.metadatapath import MetadataPath
-from dataladmetadatamodel.metadatarootrecord import MetadataRootRecord
 from dataladmetadatamodel.versionlist import (
     VersionList,
     VersionRecord,
@@ -39,16 +40,27 @@ class TestVersionListMapper(unittest.TestCase):
 
     def test_complex_unmapping(self):
 
-        with mock.patch("dataladmetadatamodel.mapper.gitmapper.versionlistmapper.git_save_json") as save_json, \
-             mock.patch("dataladmetadatamodel.mapper.gitmapper.metadatamapper.git_save_str") as save_str, \
-             mock.patch("dataladmetadatamodel.mapper.gitmapper.metadatarootrecordmapper.git_save_json") as save_json_2, \
-             mock.patch("dataladmetadatamodel.mapper.gitmapper.mtreenodemapper.git_save_tree_node") as save_tree_node, \
-             mock.patch("dataladmetadatamodel.mapper.gitmapper.versionlistmapper.git_update_ref") as update_ref:
+        with mock.patch("dataladmetadatamodel.mapper.gitmapper."
+                        "versionlistmapper.git_save_json") as save_json, \
+             mock.patch("dataladmetadatamodel.mapper.gitmapper."
+                        "metadatamapper.git_save_str") as save_str, \
+             mock.patch("dataladmetadatamodel.mapper.gitmapper."
+                        "metadatarootrecordmapper.git_save_json") as save_json_2, \
+             mock.patch("dataladmetadatamodel.mapper.gitmapper."
+                        "mtreenodemapper.git_save_tree_node") as save_tree_node, \
+             mock.patch("dataladmetadatamodel.mapper.gitmapper."
+                        "gitblobcache.git_save_file_list") as file_list_save, \
+             mock.patch("dataladmetadatamodel.mapper.gitmapper."
+                        "versionlistmapper.git_update_ref"):
 
-            save_json.configure_mock(return_value=get_location(0))
-            save_str.configure_mock(return_value=get_location(1))
-            save_json_2.configure_mock(return_value=get_location(3))
-            save_tree_node.configure_mock(return_value=get_location(4))
+            save_json.return_value = get_location(0)
+            save_str.return_value = get_location(1)
+            save_json_2.return_value = get_location(3)
+            save_tree_node.return_value = get_location(4)
+            file_list_save.side_effect = lambda r, l: [
+                hash_blob(open(e, "rb").read())
+                for e in l
+            ]
 
             version_list = VersionList(initial_set={
                 "v0": VersionRecord(

--- a/dataladmetadatamodel/mtreeproxy.py
+++ b/dataladmetadatamodel/mtreeproxy.py
@@ -68,15 +68,17 @@ class MTreeProxy:
 
         # TODO: ugly:
         from .filetree import FileTree
+
+        cache_destination = destination or self.mtree.realm
         if isinstance(self, FileTree):
-            MetadataGitMapper.cache_realm(destination)
+            MetadataGitMapper.cache_realm(cache_destination)
 
         reference = self.mtree.write_out(destination,
                                          backend_type,
                                          force_write)
 
         if isinstance(self, FileTree):
-            MetadataGitMapper.flush_realm(destination)
+            MetadataGitMapper.flush_realm(cache_destination)
 
         if not reference.is_none_reference():
             add_tree_reference(GitReference.TREES,

--- a/dataladmetadatamodel/mtreeproxy.py
+++ b/dataladmetadatamodel/mtreeproxy.py
@@ -7,6 +7,7 @@ from typing import (
 )
 
 from dataladmetadatamodel.mappableobject import MappableObject
+from dataladmetadatamodel.mapper.gitmapper.metadatamapper import MetadataGitMapper
 from dataladmetadatamodel.mapper.gitmapper.objectreference import (
     add_tree_reference,
     GitReference,
@@ -61,9 +62,21 @@ class MTreeProxy:
                   backend_type: str = "git",
                   force_write: bool = False) -> Reference:
 
+        # Since a file tree might contain a large number
+        # of metadata entries and since each entry requires
+        # two blobs to be written, we use a write-cache.
+
+        # TODO: ugly:
+        from .filetree import FileTree
+        if isinstance(self, FileTree):
+            MetadataGitMapper.cache_realm(destination)
+
         reference = self.mtree.write_out(destination,
                                          backend_type,
                                          force_write)
+
+        if isinstance(self, FileTree):
+            MetadataGitMapper.flush_realm(destination)
 
         if not reference.is_none_reference():
             add_tree_reference(GitReference.TREES,

--- a/dataladmetadatamodel/tests/test_datasettree.py
+++ b/dataladmetadatamodel/tests/test_datasettree.py
@@ -1,11 +1,10 @@
 import subprocess
 import tempfile
 import unittest
-from pathlib import Path
 from unittest.mock import patch
 
 from dataladmetadatamodel.datasettree import DatasetTree
-from dataladmetadatamodel.mapper.gitmapper.objectreference import flush_object_references
+from dataladmetadatamodel.mapper.gitmapper.gitblobcache import hash_blob
 from dataladmetadatamodel.metadatapath import MetadataPath
 from dataladmetadatamodel.metadatarootrecord import MetadataRootRecord
 from dataladmetadatamodel.tests.utils import (
@@ -82,12 +81,18 @@ class TestReferenceCreation(unittest.TestCase):
                       "mtreenodemapper.git_save_tree_node") as save_tree_node, \
                 patch("dataladmetadatamodel.mapper.gitmapper."
                       "metadatarootrecordmapper.git_save_json") as save_json, \
+                patch("dataladmetadatamodel.mapper.gitmapper."
+                      "gitblobcache.git_save_file_list") as file_list_save, \
                 patch("dataladmetadatamodel.mtreeproxy."
                       "add_tree_reference") as add_tree_ref:
 
             save_str.return_value = get_location(1)
             save_tree_node.return_value = get_location(2)
             save_json.return_value = get_location(3)
+            file_list_save.side_effect = lambda r, l: [
+                hash_blob(open(e, "rb").read())
+                for e in l
+            ]
 
             dataset_tree.write_out("/tmp/t1")
 

--- a/dataladmetadatamodel/tests/test_filetree.py
+++ b/dataladmetadatamodel/tests/test_filetree.py
@@ -12,8 +12,9 @@ from dataladmetadatamodel.metadata import (
     Metadata,
     MetadataInstance,
 )
-from dataladmetadatamodel.metadatapath import MetadataPath
+from dataladmetadatamodel.mapper.gitmapper.gitblobcache import hash_blob
 from dataladmetadatamodel.mapper.gitmapper.objectreference import flush_object_references
+from dataladmetadatamodel.metadatapath import MetadataPath
 from dataladmetadatamodel.tests.utils import (
     assert_file_trees_equal,
     create_file_tree_with_metadata,
@@ -108,12 +109,18 @@ class TestReferenceCreation(unittest.TestCase):
                       "mtreenodemapper.git_save_tree_node") as save_tree_node, \
                 patch("dataladmetadatamodel.mapper.gitmapper."
                       "metadatarootrecordmapper.git_save_json") as save_json, \
+                patch("dataladmetadatamodel.mapper.gitmapper."
+                      "gitblobcache.git_save_file_list") as file_list_save, \
                 patch("dataladmetadatamodel.mtreeproxy."
                       "add_tree_reference") as add_tree_ref:
 
             save_str.return_value = get_location(1)
             save_tree_node.return_value = get_location(2)
             save_json.return_value = get_location(3)
+            file_list_save.side_effect = lambda r, l: [
+                hash_blob(open(e, "rb").read())
+                for e in l
+            ]
 
             file_tree.write_out("/tmp/t1")
 


### PR DESCRIPTION
This PR introduces a cache for writing git-blobs. The cache stores git blobs in a temporary directory and use `git hash-object` with a list of the stored files when the cache is flushed.

This reduces the number of extern `git`-calls from #metadata-path to nearly 1, more precisely: log(#metadata-path) with a quite small constant multiplier).

This PR increases the performance of metadata writing in the worst-case scenario at least by the factor 10.
