### PR TITLE
Tree based object reference store

### DIFF
--- a/dataladmetadatamodel/mapper/gitmapper/gitbackend/subprocess.py
+++ b/dataladmetadatamodel/mapper/gitmapper/gitbackend/subprocess.py
@@ -35,13 +35,16 @@ def checked_execute(arguments: Union[str, List[str]],
 
     result = execute(arguments, stdin_content)
     if result.returncode != 0:
-        raise RuntimeError(
+        error = RuntimeError(
             f"Command failed (exit code: {result.returncode}) "
             f"{' '.join(arguments)}:\n"
             f"STDOUT:\n"
             f"{result.stdout.decode()}"
             f"STDERR:\n"
             f"{result.stderr.decode()}")
+        error.stdout = result.stdout.decode()
+        error.stderr = result.stderr.decode()
+        raise error
     return (
         result.stdout.decode().splitlines(),
         result.stderr.decode().splitlines())

--- a/dataladmetadatamodel/mapper/gitmapper/gitbackend/subprocess.py
+++ b/dataladmetadatamodel/mapper/gitmapper/gitbackend/subprocess.py
@@ -174,6 +174,14 @@ def git_update_ref(repo_dir: str, ref_name: str, location: str) -> None:
     checked_execute(cmd_line)
 
 
+def git_delete_ref(repo_dir: str, ref_name: str) -> None:
+    cmd_line = git_command_line(
+        repo_dir,
+        "update-ref",
+        ["-d", ref_name])
+    checked_execute(cmd_line)
+
+
 def git_fetch_object(repo_dir: str,
                      remote_repo: str,
                      remote_reference: str):

--- a/dataladmetadatamodel/mapper/gitmapper/gitbackend/subprocess.py
+++ b/dataladmetadatamodel/mapper/gitmapper/gitbackend/subprocess.py
@@ -61,7 +61,7 @@ def git_command_line(repo_dir: str,
            ] + arguments
 
 
-def git_text_result(cmd_line):
+def git_text_result(cmd_line: Union[str, List[str]]):
     result = checked_execute(cmd_line)[0]
     return "\n".join(result)
 
@@ -95,25 +95,27 @@ def git_init(repo_dir: str) -> None:
 
 
 def git_object_exists_locally(repo_dir: str,
-                              object_reference) -> bool:
+                              object_reference: str) -> bool:
     cmd_line = git_command_line(repo_dir, "cat-file", ["-e", object_reference])
     return execute(cmd_line).returncode == 0
 
 
 def git_read_tree_node(repo_dir: str,
-                       object_reference) -> List[str]:
+                       object_reference: str) -> List[str]:
     repo_dir = adapt_for_remote(repo_dir, object_reference)
     cmd_line = git_command_line(repo_dir, "cat-file", ["-p", object_reference])
     return checked_execute(cmd_line)[0]
 
 
-def git_ls_tree(repo_dir, object_reference) -> List[str]:
+def git_ls_tree(repo_dir: str, object_reference: str) -> List[str]:
     repo_dir = adapt_for_remote(repo_dir, object_reference)
     cmd_line = git_command_line(repo_dir, "ls-tree", [object_reference])
     return checked_execute(cmd_line)[0]
 
 
-def git_ls_tree_recursive(repo_dir, object_reference, show_intermediate=False) -> List[str]:
+def git_ls_tree_recursive(repo_dir: str,
+                          object_reference: str,
+                          show_intermediate: bool = False) -> List[str]:
     repo_dir = adapt_for_remote(repo_dir, object_reference)
     if show_intermediate is True:
         cmd_line = git_command_line(repo_dir, "ls-tree", ["-r", "-t", object_reference])
@@ -122,12 +124,12 @@ def git_ls_tree_recursive(repo_dir, object_reference, show_intermediate=False) -
     return checked_execute(cmd_line)[0]
 
 
-def git_save_str(repo_dir, content: str) -> str:
+def git_save_str(repo_dir: str, content: str) -> str:
     cmd_line = git_command_line(repo_dir, "hash-object", ["-w", "--stdin"])
     return checked_execute(cmd_line, stdin_content=content)[0][0]
 
 
-def git_save_file_list(repo_dir, file_list: List[str]) -> List[str]:
+def git_save_file_list(repo_dir: str, file_list: List[str]) -> List[str]:
     cmd_line = git_command_line(
         repo_dir,
         "hash-object",
@@ -137,11 +139,11 @@ def git_save_file_list(repo_dir, file_list: List[str]) -> List[str]:
         stdin_content="\n".join(file_list))[0]
 
 
-def git_save_json(repo_dir, json_object: Union[Dict, List]) -> str:
+def git_save_json(repo_dir: str, json_object: Union[Dict, List]) -> str:
     return git_save_str(repo_dir, json.dumps(json_object))
 
 
-def git_save_tree_node(repo_dir,
+def git_save_tree_node(repo_dir: str,
                        entry_set: Iterable[Tuple[str, str, str, str]]
                        ) -> str:
 
@@ -153,7 +155,7 @@ def git_save_tree_node(repo_dir,
     return checked_execute(cmd_line, stdin_content=tree_spec)[0][0]
 
 
-def git_save_tree(repo_dir,
+def git_save_tree(repo_dir: str,
                   entry_set: Iterable[Tuple[str, str, str, str]]
                   ) -> str:
     tree_spec = "\n".join([

--- a/dataladmetadatamodel/mapper/gitmapper/metadatamapper.py
+++ b/dataladmetadatamodel/mapper/gitmapper/metadatamapper.py
@@ -78,7 +78,7 @@ class MetadataGitMapper(Mapper):
         # JSON-strings that are stored in the
         # repository.
         metadata_blob_location = git_save_str(realm, metadata.to_json())
-        add_blob_reference(GitReference.BLOBS, metadata_blob_location)
+        add_blob_reference(metadata_blob_location)
 
         # Save reference. NB we don't have to save
         # metadata_reference_blob_location to the
@@ -106,7 +106,7 @@ class MetadataGitMapper(Mapper):
         # Cache metadata, and cache a reference object. the
         # following code is "cache"-equivalent to the immediate case
         metadata_blob_location = cache.cache_blob(realm, metadata.to_json())
-        add_blob_reference(GitReference.BLOBS, metadata_blob_location)
+        add_blob_reference(metadata_blob_location)
 
         metadata_reference_blob_location = cache.cache_blob(
             realm,

--- a/dataladmetadatamodel/mapper/gitmapper/objectreference.py
+++ b/dataladmetadatamodel/mapper/gitmapper/objectreference.py
@@ -10,8 +10,6 @@ from ...mapper.reference import none_location
 from .treeupdater import EntryType
 
 
-object_reference_name = "refs/datalad_local/object-references"
-
 logger = logging.getLogger("datalad.metalad.gitmapper.objectreference")
 
 cached_object_references: Set[Tuple[EntryType, str]] = set()
@@ -20,6 +18,7 @@ cached_object_references: Set[Tuple[EntryType, str]] = set()
 class GitReference(enum.Enum):
     TREE_VERSION_LIST = "refs/datalad/dataset-tree-version-list"
     UUID_SET = "refs/datalad/dataset-uuid-set"
+    OBJECT_REFERENCES = "refs/datalad_local/object-references"
     LEGACY_TREES = "refs/datalad/object-references/trees"
     LEGACY_BLOBS = "refs/datalad/object-references/blobs"
 
@@ -120,12 +119,12 @@ def flush_object_references(realm: Path):
 
         with locked_backend(realm):
             try:
-                root_entries = _get_dir(realm, object_reference_name)
+                root_entries = _get_dir(realm, GitReference.OBJECT_REFERENCES.value)
             except RuntimeError:
                 root_entries = []
 
             tree_hash = add_paths(realm, path_infos, root_entries)
-            git_update_ref(str(realm), object_reference_name, tree_hash)
+            git_update_ref(str(realm), GitReference.OBJECT_REFERENCES.value, tree_hash)
 
         cached_object_references = set()
 

--- a/dataladmetadatamodel/mapper/gitmapper/objectreference.py
+++ b/dataladmetadatamodel/mapper/gitmapper/objectreference.py
@@ -20,8 +20,8 @@ cached_object_references: Set[Tuple[EntryType, str]] = set()
 class GitReference(enum.Enum):
     TREE_VERSION_LIST = "refs/datalad/dataset-tree-version-list"
     UUID_SET = "refs/datalad/dataset-uuid-set"
-    TREES = "refs/datalad/object-references/trees"
-    BLOBS = "refs/datalad/object-references/blobs"
+    OLD_TREES = "refs/datalad/object-references/trees"
+    OLD_BLOBS = "refs/datalad/object-references/blobs"
 
 
 def add_object_reference(entry_type: EntryType,
@@ -71,11 +71,11 @@ def flush_object_references(realm: Path):
         cached_object_references = set()
 
 
-def add_tree_reference(_, object_hash: str):
+def add_tree_reference(object_hash: str):
     add_object_reference(EntryType.Directory, object_hash)
 
 
-def add_blob_reference(_, object_hash: str):
+def add_blob_reference(object_hash: str):
     add_object_reference(EntryType.File, object_hash)
 
 

--- a/dataladmetadatamodel/mapper/gitmapper/objectreference.py
+++ b/dataladmetadatamodel/mapper/gitmapper/objectreference.py
@@ -23,7 +23,7 @@ class GitReference(enum.Enum):
     LEGACY_BLOBS = "refs/datalad/object-references/blobs"
 
 
-checked_legacy_store = False
+checked_legacy_stores = set()
 
 
 def add_object_reference(entry_type: EntryType,
@@ -61,10 +61,8 @@ def add_legacy_store_entries(realm: Path) -> Tuple[bool, bool]:
     """
     Add legacy store entries to the cache, if they exist
     """
-    global checked_legacy_store
-
-    if checked_legacy_store is False:
-        checked_legacy_store = True
+    if realm not in checked_legacy_stores:
+        checked_legacy_stores.add(realm)
 
         legacy_trees_added = add_legacy_store_entries_from(
             realm,

--- a/dataladmetadatamodel/mapper/gitmapper/tests/test_metadatamapper.py
+++ b/dataladmetadatamodel/mapper/gitmapper/tests/test_metadatamapper.py
@@ -89,9 +89,15 @@ class TestMetadataMapper(unittest.TestCase):
                 mock.patch("dataladmetadatamodel.mapper.gitmapper"
                            ".metadatamapper.git_save_str") as save_str, \
                 mock.patch("dataladmetadatamodel.mapper.gitmapper"
+                           ".treeupdater.git_save_tree_node") as save_tree_node, \
+                mock.patch("dataladmetadatamodel.mapper.gitmapper"
+                           ".gitbackend.subprocess.git_update_ref") as update_ref, \
+                mock.patch("dataladmetadatamodel.mapper.gitmapper"
                            ".metadatamapper.add_blob_reference") as add_ref:
 
             save_str.return_value = get_location(1)
+            save_tree_node.return_value = get_location(2)
+            update_ref.return_value = get_location(3)
 
             realm = "/tmp/t1"
             reference = metadata.write_out(realm, "git")
@@ -107,6 +113,7 @@ class TestMetadataMapper(unittest.TestCase):
 
             # ensure that the object reference stores are updated
             add_ref.assert_called_once()
+            assert 0 == 1, "check the asserts above"
 
     def test_double_cache_detection(self):
         metadata_mapper: MetadataGitMapper = cast(

--- a/dataladmetadatamodel/mapper/gitmapper/tests/test_metadatamapper.py
+++ b/dataladmetadatamodel/mapper/gitmapper/tests/test_metadatamapper.py
@@ -113,7 +113,6 @@ class TestMetadataMapper(unittest.TestCase):
 
             # ensure that the object reference stores are updated
             add_ref.assert_called_once()
-            assert 0 == 1, "check the asserts above"
 
     def test_double_cache_detection(self):
         metadata_mapper: MetadataGitMapper = cast(

--- a/dataladmetadatamodel/mapper/gitmapper/tests/test_objectreferences.py
+++ b/dataladmetadatamodel/mapper/gitmapper/tests/test_objectreferences.py
@@ -1,0 +1,131 @@
+import subprocess
+import tempfile
+from hashlib import sha1
+from pathlib import Path
+from typing import (
+    List,
+    Iterable,
+    Tuple,
+)
+
+from nose.tools import (
+    assert_false,
+    assert_in,
+)
+
+from ..utils import create_git_repo
+
+from ..gitbackend.subprocess import (
+    git_ls_tree,
+    git_save_tree_node,
+    git_update_ref,
+)
+from ..objectreference import (
+    GitReference,
+    flush_object_references,
+)
+from ..treeupdater import EntryType
+
+
+default_repo = {
+    "a": {
+        "af1": "1234"
+    },
+    "b": {
+        "bf1": "aasdsd"
+    },
+    "LICENSE": "license content"
+}
+
+
+def _does_ref_exist(realm: Path, reference: str) -> bool:
+    result = subprocess.run(
+        ["git", "--git-dir", str(realm / ".git"), "show-ref", reference])
+    return result.returncode == 0
+
+
+def _create_hash(n: int) -> str:
+    return sha1(f"index: {n}".encode()).hexdigest()
+
+
+def _create_legacy_tree(start_index: int,
+                        stop_index: int,
+                        entry_type: EntryType
+                        ) -> Iterable[Tuple[str, str, str, str]]:
+
+    flag, object_type = {
+        EntryType.File: ("100644", "blob"),
+        EntryType.Directory: ("040000", "tree")
+    }[entry_type]
+
+    return (
+        (
+            flag,
+            object_type,
+            _create_hash(i),
+            "object_reference:" + _create_hash(i)
+         )
+        for i in range(start_index, stop_index)
+    )
+
+
+def _write_legacy_tree(realm: Path,
+                       reference: str,
+                       entry_type: EntryType,
+                       start_index: int,
+                       stop_index: int,
+                       ):
+
+    tree_hash = git_save_tree_node(
+        str(realm),
+        _create_legacy_tree(start_index, stop_index, entry_type))
+    git_update_ref(str(realm), reference, tree_hash)
+
+
+def _read_tree(realm: Path, reference: str) -> Iterable[Tuple[str, str]]:
+    return (
+        (line.split()[3], line.split()[2])
+        for line in git_ls_tree(str(realm), reference))
+
+
+def _read_reference_tree(realm: Path,
+                         reference: str,
+                         parts: List[str]
+                         ) -> List[str]:
+    """A simple recursive reference tree reader"""
+
+    if len(parts) == 4:
+        assert reference[9:] == parts[3]
+        return ["".join(parts)]
+
+    result = []
+    for name, sub_reference in _read_tree(realm, reference):
+        sub_results = _read_reference_tree(realm, sub_reference, parts + [name])
+        result.extend(sub_results)
+    return result
+
+
+def test_old_reference_conversion():
+    with tempfile.TemporaryDirectory() as td:
+        realm = Path(td)
+        create_git_repo(realm, {"readme.md": "test repo"})
+
+        _write_legacy_tree(realm, GitReference.LEGACY_BLOBS.value, EntryType.File, 100, 200)
+        _write_legacy_tree(realm, GitReference.LEGACY_TREES.value, EntryType.Directory, 200, 300)
+
+        flush_object_references(realm)
+
+        references = _read_reference_tree(
+            realm,
+            GitReference.OBJECT_REFERENCES.value,
+            [])
+
+        # Check that the new references exist.
+        for i in range(100, 300):
+            assert_in(_create_hash(i), references)
+
+        # Check that the old references are gone by trying to update them
+        assert_false(_does_ref_exist(realm, GitReference.LEGACY_BLOBS.value))
+        assert_false(_does_ref_exist(realm, GitReference.LEGACY_TREES.value))
+
+

--- a/dataladmetadatamodel/mapper/gitmapper/tests/test_objectreferences.py
+++ b/dataladmetadatamodel/mapper/gitmapper/tests/test_objectreferences.py
@@ -27,17 +27,6 @@ from ..objectreference import (
 from ..treeupdater import EntryType
 
 
-default_repo = {
-    "a": {
-        "af1": "1234"
-    },
-    "b": {
-        "bf1": "aasdsd"
-    },
-    "LICENSE": "license content"
-}
-
-
 def _does_ref_exist(realm: Path, reference: str) -> bool:
     result = subprocess.run(
         ["git", "--git-dir", str(realm / ".git"), "show-ref", reference])

--- a/dataladmetadatamodel/mapper/gitmapper/tests/test_treeupdater.py
+++ b/dataladmetadatamodel/mapper/gitmapper/tests/test_treeupdater.py
@@ -1,0 +1,248 @@
+import subprocess
+import tempfile
+from collections import defaultdict
+from pathlib import Path
+from typing import (
+    Dict,
+    Optional,
+)
+from unittest.mock import patch
+
+from nose.tools import (
+    assert_equal,
+    assert_in,
+)
+
+from ..gitbackend.subprocess import (
+    git_ls_tree,
+    git_ls_tree_recursive,
+)
+from ..treeupdater import (
+    EntryType,
+    PathInfo,
+    _get_dir,
+    _write_dir,
+    add_paths
+)
+
+
+default_repo = {
+    "a": {
+        "af1": "1234"
+    },
+    "b": {
+        "bf1": "aasdsd"
+    },
+    "LICENSE": "license content"
+}
+
+
+def _create_file_tree(location: Path, content: Dict):
+    for name, value_or_dict in content.items():
+        new_location = location / name
+        if isinstance(value_or_dict, str):
+            new_location.write_text(value_or_dict)
+        else:
+            new_location.mkdir()
+            _create_file_tree(new_location, value_or_dict)
+
+
+def _create_repo(location: Path, content: Optional[Dict] = None):
+    content = content or default_repo
+    subprocess.run(["git", "init", str(location)], check=True)
+    _create_file_tree(location, content)
+    subprocess.run(
+        ["git", "-C", str(location), "add", "."],
+        check=True
+    )
+
+    subprocess.run(
+        ["git", "-C", str(location), "commit", "-m", "create repo"],
+        check=True
+    )
+
+    commit = subprocess.run(
+        ["git", "-C", str(location), "cat-file", "-p", "HEAD"],
+        check=True,
+        stdout=subprocess.PIPE
+    )
+    return commit.stdout.decode().splitlines()[0].split()[1]
+
+
+def test_basic():
+    path_infos = [
+        PathInfo(["a", "b", "c"], "000000000000000000000000000000000000000c", EntryType.File),
+        PathInfo(["a", "b", "d"], "000000000000000000000000000000000000000d", EntryType.File),
+        PathInfo(["tools", "ttttc"], "000000000000000000000000000000000000000c", EntryType.File),
+        PathInfo(["a", "d"], "000000000000000000000000000000000000000d", EntryType.File),
+        PathInfo(["b", "a"], "000000000000000000000000000000000000000a", EntryType.File),
+        PathInfo(["c", "b"], "000000000000000000000000000000000000000b", EntryType.File),
+        PathInfo(["d"], "000000000000000000000000000000000000000d", EntryType.File),
+        PathInfo(["LICENSE"], "00000000000000000000000000000000000000a0", EntryType.File)
+    ]
+
+    with tempfile.TemporaryDirectory() as td:
+        repo_path = Path(td)
+        tree_hash = _create_repo(repo_path)
+        root_entries = _get_dir(repo_path, tree_hash)
+        result = add_paths(repo_path, path_infos, root_entries)
+
+        lines = git_ls_tree_recursive(str(repo_path), result)
+        for path_info in path_infos:
+            assert_in(
+                f"100644 blob {path_info.object_hash}\t{'/'.join(path_info.elements)}",
+                lines
+            )
+
+
+def test_dir_adding():
+    path_infos = [
+        PathInfo(
+            ["a_dir"],
+            "000000000000000000000000000000000000000c",
+            EntryType.Directory
+        )
+    ]
+
+    with tempfile.TemporaryDirectory() as td:
+        repo_path = Path(td)
+        tree_hash = _create_repo(repo_path)
+        root_entries = _get_dir(repo_path, tree_hash)
+        result = add_paths(repo_path, path_infos, root_entries)
+
+        lines = git_ls_tree(str(repo_path), result)
+        for path_info in path_infos:
+            assert_in(
+                f"040000 tree {path_info.object_hash}\t{'/'.join(path_info.elements)}",
+                lines
+            )
+
+
+def test_dir_overwrite_error():
+    path_infos = [
+        PathInfo(
+            ["a"],
+            "000000000000000000000000000000000000000c",
+            EntryType.File
+        )
+    ]
+
+    with tempfile.TemporaryDirectory() as td:
+        repo_path = Path(td)
+        tree_hash = _create_repo(repo_path)
+        root_entries = _get_dir(repo_path, tree_hash)
+
+        try:
+            add_paths(repo_path, path_infos, root_entries)
+            raise RuntimeError("did not get expected ValueError")
+        except ValueError as ve:
+            assert_equal(ve.args[0], "cannot convert Directory to File: a")
+
+
+def test_file_overwrite_error():
+    path_infos = [
+        PathInfo(
+            ["LICENSE"],
+            "000000000000000000000000000000000000000c",
+            EntryType.Directory
+        )
+    ]
+
+    with tempfile.TemporaryDirectory() as td:
+        repo_path = Path(td)
+        tree_hash = _create_repo(repo_path)
+        root_entries = _get_dir(repo_path, tree_hash)
+
+        try:
+            add_paths(repo_path, path_infos, root_entries)
+            raise RuntimeError("did not get expected ValueError")
+        except ValueError as ve:
+            assert_equal(
+                ve.args[0],
+                "cannot convert File to Directory: LICENSE")
+
+
+def test_minimal_invocation():
+
+    complex_repo = {
+        "a": {
+            "a_a": {
+                "a_a_f1": "content of a_a_f1"
+            },
+            "a_b": {
+                "a_b_f1": "content of a_b_f1"
+            }
+        },
+        "b": {
+            "b_a": {
+                "b_a_f1": "content of b_a_f1"
+            },
+            "b_b": {
+                "b_b_f1": "content of b_b_f1"
+            }
+        },
+        "c": {
+            "c_f1": "content of c_f1"
+        }
+    }
+
+    path_infos = [
+        PathInfo(
+            ["a", "a_a", "a_a_a", "a_a_a_f1"],
+            "000000000000000000000000000000000000000c",
+            EntryType.File
+        ),
+        PathInfo(
+            ["a", "a_a", "a_a_a", "a_a_a_f2"],
+            "000000000000000000000000000000000000000c",
+            EntryType.File
+        ),
+        PathInfo(
+            ["a", "a_a", "a_a_f1"],
+            "000000000000000000000000000000000000000c",
+            EntryType.File
+        ),
+        PathInfo(
+            ["a", "a_b", "a_b_f2"],
+            "000000000000000000000000000000000000000c",
+            EntryType.File
+        ),
+    ]
+
+    with \
+            tempfile.TemporaryDirectory() as td, \
+            patch("dataladmetadatamodel.mapper.gitmapper.treeupdater._get_dir") as gd_mock, \
+            patch("dataladmetadatamodel.mapper.gitmapper.treeupdater._write_dir") as wd_mock:
+
+        def gd_counter(*args):
+            get_calls[args[1]] += 1
+            return _get_dir(*args)
+
+        def wd_counter(*args):
+            write_calls[args] += 1
+            return _write_dir(*args)
+
+        get_calls = defaultdict(int)
+        write_calls = defaultdict(int)
+        gd_mock.side_effect = gd_counter
+        wd_mock.side_effect = wd_counter
+
+        repo_path = Path(td)
+        tree_hash = _create_repo(repo_path, complex_repo)
+        root_entries = _get_dir(repo_path, tree_hash)
+
+        result = add_paths(repo_path, path_infos, root_entries)
+
+        # Assert that a node is only read once
+        assert all(map(lambda x: x == 1, get_calls.values()))
+        assert len(get_calls) == 3
+        # Assert that a node is only written once
+        assert all(map(lambda x: x == 1, write_calls.values()))
+        assert len(write_calls) == 5
+
+        lines = git_ls_tree_recursive(str(repo_path), result)
+        for path_info in path_infos:
+            assert_in(
+                f"100644 blob {path_info.object_hash}\t{'/'.join(path_info.elements)}",
+                lines)
+

--- a/dataladmetadatamodel/mapper/gitmapper/treeupdater.py
+++ b/dataladmetadatamodel/mapper/gitmapper/treeupdater.py
@@ -1,0 +1,230 @@
+"""
+Multi object tree updater
+
+The multi object tree updater allows to update a git-tee with a tree that is
+defined by object-hashes and their paths. It uses only the minimal necessary
+read/write operations to perform this task.
+
+This is mainly used by the object reference system to efficiently store object
+references, by using prefixes of the object-hashes as "directory names", i.e. as
+tree reference names.
+"""
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import (
+    Dict,
+    Iterable,
+    List,
+    Tuple,
+    Union,
+)
+
+from .gitbackend.subprocess import git_read_tree_node
+from .gitbackend.subprocess import git_save_tree_node
+
+
+logger = logging.getLogger("datalad.metalad.gitmapper.treeupdater")
+
+
+class EntryType(Enum):
+    Directory = 0
+    File = 1
+
+
+@dataclass
+class DirEntry:
+    type: EntryType
+    object_hash: str
+    name: str
+
+    def __post_init__(self):
+        _check_hash_and_type(self)
+
+    def get_git_tree_entry_elements(self) -> Tuple[str, str, str, str]:
+        if self.type == EntryType.Directory:
+            flag = "040000"
+            entry_type = "tree"
+        else:
+            flag = "100644"
+            entry_type = "blob"
+        return flag, entry_type, self.object_hash, self.name
+
+
+@dataclass
+class PathInfo:
+    """
+    Instances of this class represent object hashes and the path under which
+    those hashes should be, or are, available.
+    """
+    elements: List[str]
+    object_hash: str
+    type: EntryType
+
+    def __post_init__(self):
+        _check_hash_and_type(self)
+
+    def first(self) -> str:
+        return self.elements[0]
+
+    def is_file(self) -> bool:
+        return self.is_leaf() and self.type == EntryType.File
+
+    def is_leaf(self) -> bool:
+        return len(self.elements) == 1
+
+    def stripped_by(self, amount: int) -> "PathInfo":
+        return PathInfo(
+            self.elements[amount:],
+            self.object_hash,
+            self.type)
+
+
+def _check_hash_and_type(obj: Union[DirEntry, PathInfo]):
+    if len(obj.object_hash) != 40:
+        raise ValueError(
+            f"{type(obj).__name__}: hash format error ({obj.object_hash})")
+    if obj.type not in (EntryType.Directory, EntryType.File):
+        raise ValueError(
+            f"{type(obj).__name__}: unknown type: {obj.type}")
+
+
+def _check_leaf_or_directory(leaf_infos: List[PathInfo],
+                             directory_infos: Dict[str, PathInfo]):
+    """Ensure that a leaf is either a file name or a directory name
+
+    While there might only be one file named u, there might be many directories
+    named u, but only one type can exist in the new and existing directory info
+    entries.
+    """
+    # Ensure that a name at this level (a path_info.first()) is either a file
+    # name or a directory name.
+    leaf_and_dir_names = [
+        name
+        for name in [file_info.first() for file_info in leaf_infos]
+        if name in directory_infos.keys()]
+
+    if leaf_and_dir_names:
+        raise ValueError("names used for leafs and directories: " + ", ".join(
+            leaf_and_dir_names))
+
+
+def _check_leaf_uniqueness(leaf_infos: List[PathInfo]):
+    """ Ensure that a file name is only used once"""
+    duplicated_leaf_names = set([
+        file_info.first()
+        for file_info in leaf_infos
+        if [
+            file_info.first()
+            for file_info in leaf_infos
+        ].count(file_info.first()) > 1])
+
+    if duplicated_leaf_names:
+        raise ValueError("duplicated file names: " + ", ".join(
+            duplicated_leaf_names))
+
+
+def _check_entries_validity(leaf_infos: List[PathInfo],
+                            directory_infos: Dict[str, PathInfo]):
+
+    _check_leaf_or_directory(leaf_infos, directory_infos)
+    _check_leaf_uniqueness(leaf_infos)
+
+
+def _get_dir(repo: Path, object_hash: str) -> List:
+    result = []
+    for entry in git_read_tree_node(str(repo), object_hash):
+        _, object_type, object_hash, name = entry.split()
+        result.append(
+            DirEntry(
+                type=EntryType.File
+                if object_type == "blob"
+                else EntryType.Directory,
+                object_hash=object_hash,
+                name=name))
+    return result
+
+
+def _write_dir(repo: Path, entries: Iterable[DirEntry]) -> str:
+    return git_save_tree_node(
+        str(repo),
+        [entry.get_git_tree_entry_elements() for entry in entries])
+
+
+def add_paths(repo: Path,
+              path_infos: List[PathInfo],
+              root_entries: List[DirEntry]) -> str:
+    """
+    Add all path infos to the tree object defined by "root-entries". Load
+    subtrees if necessary, write subtrees, when they are completely assembled.
+
+    This method is called recursively, with path_infos shortened by one and
+    corresponding root_entries.
+    """
+
+    # Build a quickly accessible entry structure
+    root_entry_table = {
+        root_entry.name: root_entry
+        for root_entry in root_entries}
+
+    # Collect all leaf entries, i.e. path info has only one element.
+    leaf_infos = [path_info for path_info in path_infos if path_info.is_leaf()]
+
+    # Collect all directory entries, i.e. for each directory name, get all
+    # sub-paths that start with the directory name.
+    directory_infos = {
+        path_info.first(): [
+            matching_path_info.stripped_by(1)
+            for matching_path_info in path_infos
+            if matching_path_info not in leaf_infos
+            and matching_path_info.first() == path_info.first()
+        ]
+        for path_info in path_infos
+        if path_info not in leaf_infos
+    }
+
+    _check_entries_validity(leaf_infos, directory_infos)
+
+    resulting_entries = {**root_entry_table}
+
+    # Process leaf entries
+    for leaf_info in leaf_infos:
+
+        name = leaf_info.first()
+
+        existing_entry = root_entry_table.get(name, None)
+        if existing_entry:
+            if existing_entry.type != leaf_info.type:
+                raise ValueError(
+                    f"cannot convert {existing_entry.type.name} "
+                    f"to {leaf_info.type.name}: {name}")
+            logger.debug(f"modifying existing entry: {name}")
+
+        resulting_entries[name] = DirEntry(
+            type=leaf_info.type,
+            object_hash=leaf_info.object_hash,
+            name=name)
+
+    # Process non-leaf entries
+    for directory_name, sub_path_infos in directory_infos.items():
+        if directory_name in root_entry_table:
+            if root_entry_table[directory_name].type != EntryType.Directory:
+                raise ValueError(
+                    f"cannot convert file to directory: {directory_name}")
+            directory_hash = root_entry_table[directory_name].object_hash
+            sub_dir_entries = _get_dir(repo, directory_hash)
+        else:
+            sub_dir_entries = []
+
+        written_directory_hash = add_paths(
+            repo,
+            sub_path_infos,
+            sub_dir_entries)
+
+        resulting_entries[directory_name] = DirEntry(
+            type=EntryType.Directory,
+            object_hash=written_directory_hash,
+            name=directory_name)
+
+    return _write_dir(repo, resulting_entries.values())

--- a/dataladmetadatamodel/mtreeproxy.py
+++ b/dataladmetadatamodel/mtreeproxy.py
@@ -81,8 +81,7 @@ class MTreeProxy:
             MetadataGitMapper.flush_realm(cache_destination)
 
         if not reference.is_none_reference():
-            add_tree_reference(GitReference.TREES,
-                               reference.location)
+            add_tree_reference(reference.location)
         return reference
 
     def purge(self):


### PR DESCRIPTION
This PR fixes issue #11 

The PR introduces a tree-based object reference store. Each 40 hex-char reference is split up into 4 parts:

- reference[0:3]
- reference[3:6]
- reference[6:9]
- reference[9:]

The first three parts are used as directory names and the last part is used as an entry name that points to the reference itself.

The update algorithm uses the minimal necessary reads and writes to update the tree with a set of given references. That results in a O(log(n)) behavior, where n is the number of newly added references. The should reduce latencies when using, for example, `meta-add` to add data to a large metadata store in comparison to the previous implementation. The previous implementation had a runtime if O(n), where n was the number of all references.
