### PR TITLE
Issue 23: unversioned paths

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -90,8 +90,8 @@ build: off
 # init cannot use any components from the repo, because it runs prior to
 # cloning it
 init:
-  # remove windows 260-char limit on path names
-  - cmd: powershell Set-Itemproperty -path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name LongPathsEnabled -value 1
+  # remove windows 260-char limit on prefix_path names
+  - cmd: powershell Set-Itemproperty -prefix_path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name LongPathsEnabled -value 1
   # enable developer mode on windows
   # this should enable mklink without admin privileges, but it doesn't seem to work
   #- cmd: powershell tools\ci\appveyor_enable_windevmode.ps1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,7 +49,7 @@ jobs:
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+        # queries: ./prefix_path/to/local/query, your-org/your-repo/queries@main
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)

--- a/dataladmetadatamodel/_version.py
+++ b/dataladmetadatamodel/_version.py
@@ -595,7 +595,7 @@ def get_versions():
 
     try:
         root = os.path.realpath(__file__)
-        # versionfile_source is the relative path from the top of the source
+        # versionfile_source is the relative prefix_path from the top of the source
         # tree (where the .git directory might live) to this file. Invert
         # this to find the root from __file__.
         for _ in cfg.versionfile_source.split('/'):

--- a/dataladmetadatamodel/common.py
+++ b/dataladmetadatamodel/common.py
@@ -80,6 +80,7 @@ def get_top_nodes_and_metadata_root_record(
         realm: str,
         dataset_id: UUID,
         primary_data_version: str,
+        prefix_path: MetadataPath,
         dataset_tree_path: MetadataPath,
         auto_create: Optional[bool] = False
 ) -> Tuple[Optional[TreeVersionList], Optional[UUIDSet], Optional[MetadataRootRecord]]:
@@ -120,19 +121,24 @@ def get_top_nodes_and_metadata_root_record(
         uuid_version_list = VersionList()
         uuid_set.set_version_list(dataset_id, uuid_version_list)
 
+    # TODO: check for unversioned prefix_path!? Unless we assume that a version
+    #  is only saved once.
     # Get the dataset tree
     if primary_data_version in tree_version_list.versions():
-        time_stamp, dataset_tree = tree_version_list.get_dataset_tree(
-            primary_data_version)
+        time_stamp, prefix_path, dataset_tree = \
+            tree_version_list.get_dataset_tree(primary_data_version, dataset_tree_path)
     else:
         if auto_create is False:
             return None, None, None
         time_stamp = str(time.time())
         dataset_tree = DatasetTree()
+        # TODO: set prefix_path
+        # TODO: distinguish between unversioned prefix_path and dataset tree prefix_path
         tree_version_list.set_dataset_tree(
-            primary_data_version,
-            time_stamp,
-            dataset_tree)
+            primary_data_version=primary_data_version,
+            time_stamp=time_stamp,
+            prefix_path=prefix_path,
+            dataset_tree=dataset_tree)
 
     if dataset_tree_path not in dataset_tree:
         if auto_create is False:

--- a/dataladmetadatamodel/mapper/gitmapper/objectreference.py
+++ b/dataladmetadatamodel/mapper/gitmapper/objectreference.py
@@ -18,7 +18,7 @@ cached_object_references: Set[Tuple[EntryType, str]] = set()
 class GitReference(enum.Enum):
     TREE_VERSION_LIST = "refs/datalad/dataset-tree-version-list"
     UUID_SET = "refs/datalad/dataset-uuid-set"
-    OBJECT_REFERENCES = "refs/datalad_local/object-references"
+    OBJECT_REFERENCES = "refs/datalad/object-references-2.0"
     LEGACY_TREES = "refs/datalad/object-references/trees"
     LEGACY_BLOBS = "refs/datalad/object-references/blobs"
 

--- a/dataladmetadatamodel/mapper/gitmapper/tests/test_metadatamapper.py
+++ b/dataladmetadatamodel/mapper/gitmapper/tests/test_metadatamapper.py
@@ -91,9 +91,7 @@ class TestMetadataMapper(unittest.TestCase):
                 mock.patch("dataladmetadatamodel.mapper.gitmapper"
                            ".treeupdater.git_save_tree_node") as save_tree_node, \
                 mock.patch("dataladmetadatamodel.mapper.gitmapper"
-                           ".gitbackend.subprocess.git_update_ref") as update_ref, \
-                mock.patch("dataladmetadatamodel.mapper.gitmapper"
-                           ".metadatamapper.add_blob_reference") as add_ref:
+                           ".gitbackend.subprocess.git_update_ref") as update_ref:
 
             save_str.return_value = get_location(1)
             save_tree_node.return_value = get_location(2)
@@ -110,9 +108,6 @@ class TestMetadataMapper(unittest.TestCase):
             self.assertEqual(
                 json.loads(save_str.call_args_list[1][0][1]),
                 expected_reference_object)
-
-            # ensure that the object reference stores are updated
-            add_ref.assert_called_once()
 
     def test_double_cache_detection(self):
         metadata_mapper: MetadataGitMapper = cast(

--- a/dataladmetadatamodel/mapper/gitmapper/tests/test_versionlistmapper.py
+++ b/dataladmetadatamodel/mapper/gitmapper/tests/test_versionlistmapper.py
@@ -63,19 +63,21 @@ class TestVersionListMapper(unittest.TestCase):
             ]
 
             version_list = VersionList(initial_set={
-                "v0": VersionRecord(
-                    str("1.1"),
-                    MetadataPath("subset0"),
-                    MetadataRootRecord(
-                        get_uuid(0),
-                        "version1",
-                        Metadata(),
-                        create_file_tree(
-                            [MetadataPath("a/b"),
-                             MetadataPath("d/e")]
+                "v0": {
+                    MetadataPath("subset0"): VersionRecord(
+                        str("1.1"),
+                        MetadataPath("subset0"),
+                        MetadataRootRecord(
+                            get_uuid(0),
+                            "version1",
+                            Metadata(),
+                            create_file_tree(
+                                [MetadataPath("a/b"),
+                                 MetadataPath("d/e")]
+                            )
                         )
                     )
-                )
+                }
             })
 
             version_list.write_out("/tmp/t1")

--- a/dataladmetadatamodel/mapper/gitmapper/treeupdater.py
+++ b/dataladmetadatamodel/mapper/gitmapper/treeupdater.py
@@ -55,7 +55,7 @@ class DirEntry:
 @dataclass
 class PathInfo:
     """
-    Instances of this class represent object hashes and the path under which
+    Instances of this class represent object hashes and the prefix_path under which
     those hashes should be, or are, available.
     """
     elements: List[str]
@@ -156,7 +156,7 @@ def add_paths(repo: Path,
               path_infos: List[PathInfo],
               root_entries: List[DirEntry]) -> str:
     """
-    Add all path infos to the tree object defined by "root-entries". Load
+    Add all prefix_path infos to the tree object defined by "root-entries". Load
     subtrees if necessary, write subtrees, when they are completely assembled.
 
     This method is called recursively, with path_infos shortened by one and
@@ -168,7 +168,7 @@ def add_paths(repo: Path,
         root_entry.name: root_entry
         for root_entry in root_entries}
 
-    # Collect all leaf entries, i.e. path info has only one element.
+    # Collect all leaf entries, i.e. prefix_path info has only one element.
     leaf_infos = [path_info for path_info in path_infos if path_info.is_leaf()]
 
     # Collect all directory entries, i.e. for each directory name, get all

--- a/dataladmetadatamodel/mapper/gitmapper/versionlistmapper.py
+++ b/dataladmetadatamodel/mapper/gitmapper/versionlistmapper.py
@@ -40,10 +40,15 @@ class VersionListGitMapper(Mapper):
                     f"unexpected tree class in primary data-metadata "
                     f"assoc: ({reference.class_name})")
 
-            version_records[pdm_assoc["primary_data_version"]] = VersionRecord(
-                pdm_assoc["time_stamp"],
-                MetadataPath(pdm_assoc["path"]),
-                mrr_or_tree)
+            primary_data_version = pdm_assoc["primary_data_version"]
+            prefix_path = MetadataPath(pdm_assoc["path"])
+            if primary_data_version not in version_records:
+                version_records[primary_data_version] = dict()
+            version_records[primary_data_version][prefix_path] = \
+                VersionRecord(
+                    pdm_assoc["time_stamp"],
+                    prefix_path,
+                    mrr_or_tree)
 
         return version_records
 
@@ -70,10 +75,11 @@ class VersionListGitMapper(Mapper):
             {
                 "primary_data_version": primary_data_version,
                 "time_stamp": version_record.time_stamp,
-                "path": version_record.path.as_posix(),
+                "path": version_record.prefix_path.as_posix(),
                 "dataset_tree": version_record.element.write_out(realm).to_json_obj()
             }
-            for primary_data_version, version_record in version_list.version_set.items()
+            for primary_data_version, prefix_set in version_list.version_set.items()
+            for version_record in prefix_set.values()
         ]
 
         location = git_save_json(realm, json_object)

--- a/dataladmetadatamodel/mtreenode.py
+++ b/dataladmetadatamodel/mtreenode.py
@@ -159,7 +159,7 @@ class MTreeNode(MappableObject):
                            path: Optional[MetadataPath] = None
                            ) -> Optional["MTreeNode"]:
 
-        # Linear search for path
+        # Linear search for prefix_path
         path = path or MetadataPath("")
         current_node = self
         for element in path.parts:

--- a/dataladmetadatamodel/tests/test_common.py
+++ b/dataladmetadatamodel/tests/test_common.py
@@ -30,24 +30,26 @@ class TestTopLevelObjects(unittest.TestCase):
             self.assertIsNone(uuid_set)
 
             tvl, uuid_set, mrr = get_top_nodes_and_metadata_root_record(
-                "git",
-                realm,
-                uuid_0,
-                "v1",
-                MetadataPath("a/b/c"),
-                False
+                mapper_family="git",
+                realm=realm,
+                dataset_id=uuid_0,
+                primary_data_version="v1",
+                prefix_path=MetadataPath(""),
+                dataset_tree_path=MetadataPath("a/b/c"),
+                auto_create=False
             )
             self.assertIsNone(tvl)
             self.assertIsNone(uuid_set)
             self.assertIsNone(mrr)
 
             tvl, uuid_set, mrr = get_top_nodes_and_metadata_root_record(
-                "git",
-                realm,
-                uuid_0,
-                "v1",
-                MetadataPath("a/b/c"),
-                True
+                mapper_family="git",
+                realm=realm,
+                dataset_id=uuid_0,
+                primary_data_version="v1",
+                prefix_path=MetadataPath(""),
+                dataset_tree_path=MetadataPath("a/b/c"),
+                auto_create=True
             )
             self.assertIsInstance(tvl, TreeVersionList)
             self.assertIsInstance(uuid_set, UUIDSet)

--- a/dataladmetadatamodel/tests/test_datasettree.py
+++ b/dataladmetadatamodel/tests/test_datasettree.py
@@ -98,7 +98,7 @@ class TestReferenceCreation(unittest.TestCase):
 
             # We expect one call for the dataset-tree itself
             # and one call for each file-tree, one of which
-            # is anchored at each dataset path
+            # is anchored at each dataset prefix_path
             self.assertEqual(
                 add_tree_ref.call_count,
                 1 + len(dataset_test_paths)

--- a/dataladmetadatamodel/tests/test_filetree.py
+++ b/dataladmetadatamodel/tests/test_filetree.py
@@ -126,7 +126,7 @@ class TestReferenceCreation(unittest.TestCase):
 
             # We expect one call for the dataset-tree itself
             # and one call for each file-tree, one of which
-            # is anchored at each dataset path
+            # is anchored at each dataset prefix_path
             add_tree_ref.assert_called_once()
 
 

--- a/dataladmetadatamodel/tests/test_metadatapath.py
+++ b/dataladmetadatamodel/tests/test_metadatapath.py
@@ -36,7 +36,7 @@ class TestMetadataPath(unittest.TestCase):
             MetadataPath("a/b"))
 
     def test_windows_paths(self):
-        # Enforce windows path interpretation
+        # Enforce windows prefix_path interpretation
         with patch("dataladmetadatamodel.metadatapath.PurePosixPath", new=PureWindowsPath):
             metadata_path = MetadataPath("a\\b\\c")
         self.assertEqual(metadata_path, MetadataPath("a/b/c"))

--- a/dataladmetadatamodel/tests/test_uuidset.py
+++ b/dataladmetadatamodel/tests/test_uuidset.py
@@ -37,18 +37,22 @@ class TestUUIDSet(unittest.TestCase):
 
             uuid_set = UUIDSet(initial_set={
                 uuid_0: VersionList(initial_set={
-                    "v0": VersionRecord(
-                        "1.2",
-                        MetadataPath("path0"),
-                        create_dataset_tree()
-                    )
+                    "v0": {
+                        MetadataPath("path0"): VersionRecord(
+                            "1.2",
+                            MetadataPath("path0"),
+                            create_dataset_tree()
+                        )
+                    }
                 }),
                 uuid_1: VersionList(initial_set={
-                    "v0.0": VersionRecord(
-                        "1.3",
-                        MetadataPath("path0.0"),
-                        create_dataset_tree()
-                    )
+                    "v0.0": {
+                        MetadataPath("path0.0"): VersionRecord(
+                            "1.3",
+                            MetadataPath("path0.0"),
+                            create_dataset_tree()
+                        )
+                    }
                 })
             })
 
@@ -66,18 +70,22 @@ class TestUUIDSet(unittest.TestCase):
 
             uuid_set = UUIDSet(initial_set={
                 uuid_0: VersionList(initial_set={
-                    "v0": VersionRecord(
-                        "1.2",
-                        MetadataPath("path0"),
-                        create_dataset_tree()
-                    )
+                    "v0": {
+                        MetadataPath("path0"): VersionRecord(
+                            "1.2",
+                            MetadataPath("path0"),
+                            create_dataset_tree()
+                        )
+                    }
                 }),
                 uuid_1: VersionList(initial_set={
-                    "v0.0": VersionRecord(
-                        "1.3",
-                        MetadataPath("path0.0"),
-                        create_dataset_tree()
-                    )
+                    "v0.0": {
+                        MetadataPath("path0.0"): VersionRecord(
+                            "1.3",
+                            MetadataPath("path0.0"),
+                            create_dataset_tree()
+                        )
+                    }
                 })
             })
 

--- a/dataladmetadatamodel/tests/test_versionlist.py
+++ b/dataladmetadatamodel/tests/test_versionlist.py
@@ -68,16 +68,20 @@ class TestVersionList(unittest.TestCase):
             dataset_trees[1].write_out(original_dir)
 
             version_list = VersionList(initial_set={
-                "v1": VersionRecord(
-                    "0.1",
-                    MetadataPath("a"),
-                    dataset_trees[0]
-                ),
-                "v2": VersionRecord(
-                    "0.2",
-                    MetadataPath("b"),
-                    dataset_trees[1]
-                )
+                "v1": {
+                    MetadataPath("a"): VersionRecord(
+                        "0.1",
+                        MetadataPath("a"),
+                        dataset_trees[0]
+                    )
+                },
+                "v2": {
+                    MetadataPath("b"): VersionRecord(
+                        "0.2",
+                        MetadataPath("b"),
+                        dataset_trees[1]
+                    )
+                }
             })
 
             version_list.write_out(original_dir)
@@ -102,7 +106,7 @@ class TestVersionList(unittest.TestCase):
             # Compare the version lists, taking modified dataset tree paths into account
             for primary_version, (_, path, dataset_tree) in version_list.versioned_elements:
                 expected_path = path_prefix / path
-                _, copy_path, copied_dataset_tree = copied_version_list.get_versioned_element(primary_version)
+                _, copy_path, copied_dataset_tree = copied_version_list.get_versioned_element(primary_version, expected_path)
                 self.assertEqual(expected_path, copy_path)
                 dataset_tree.read_in()
                 copied_dataset_tree.read_in()

--- a/dataladmetadatamodel/tests/utils.py
+++ b/dataladmetadatamodel/tests/utils.py
@@ -196,8 +196,14 @@ def assert_version_lists_equal(test_case: unittest.TestCase,
                                unsafe: bool
                                ):
 
-    a_entries = [a.get_versioned_element(pdv) for pdv in a.versions()]
-    b_entries = [b.get_versioned_element(pdv) for pdv in b.versions()]
+    a_entries = [
+        a.get_versioned_element(pdv, pref)
+        for pdv, pref in a.versions_and_prefix_paths()
+    ]
+    b_entries = [
+        b.get_versioned_element(pdv, pref)
+        for pdv, pref in b.versions_and_prefix_paths()
+    ]
 
     for a_entry, b_entry in zip(a_entries, b_entries):
         test_case.assertEqual(a_entry[0], b_entry[0])

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = datalad-metadata-model
-version = 0.2.0rc4
+version = 0.2.0rc5
 url = https://github.com/datalad/datalad-metadata-model
 author = The DataLad Team and Contributors
 author_email = team@datalad.org

--- a/tools/metadata_creator/create.py
+++ b/tools/metadata_creator/create.py
@@ -33,7 +33,7 @@ def _create_tree_paths(tree_spec: List[Tuple[int, int]], upper_levels: List[int]
             for node_number in range(tree_spec[0][0])
         ]
 
-    # If we create a path that identifies a dataset, add it the the result list
+    # If we create a prefix_path that identifies a dataset, add it the the result list
     result = [
         f"dataset{upper_level_postfix}.{node_number}"
         for node_number in range(tree_spec[0][0])

--- a/tools/metadata_creator/filetreecreator.py
+++ b/tools/metadata_creator/filetreecreator.py
@@ -23,7 +23,7 @@ def should_follow(entry: os.DirEntry, ignore_dot_dirs) -> bool:
 
 
 def read_files(path: str, ignore_dot_dirs: bool = True) -> Generator[Tuple[str, os.DirEntry], None, None]:
-    """ Return all sub-entries of path that are files """
+    """ Return all sub-entries of prefix_path that are files """
 
     entries = list(os.scandir(path))
     while entries:
@@ -42,7 +42,7 @@ def get_extractor_run(path: str,
     stat = entry.stat(follow_symlinks=False)
     return {
         "info": f"file-level test metadata for parameter set #{parameter_set_count}",
-        "path": path,
+        "prefix_path": path,
         "size": stat.st_size,
         "atime": stat.st_atime,
         "ctime": stat.st_ctime,

--- a/tools/metadata_creator/main.py
+++ b/tools/metadata_creator/main.py
@@ -66,7 +66,7 @@ def from_template(ctx, dataset_path, realm, parameter_set_count):
     \b
     Usage:
     from-template [DATASET_PATH] [REALM]
-    DATASET_PATH: path of the datalad dataset the should be mimicked
+    DATASET_PATH: prefix_path of the datalad dataset the should be mimicked
     REALM: realm in which the metadata should be stored
     """
 

--- a/tools/metadata_creator/mrrcreator.py
+++ b/tools/metadata_creator/mrrcreator.py
@@ -44,7 +44,7 @@ def create_metadata_root_record(mapper_family,
                 ExtractorConfiguration("1.2.3", parameters),
                 {
                     "info": f"dataset-level test metadata for parameter set #{count}",
-                    "path": relative_path
+                    "prefix_path": relative_path
                 }
             )
 

--- a/tools/metadata_creator/utils.py
+++ b/tools/metadata_creator/utils.py
@@ -66,4 +66,4 @@ def read_datasets(path: str, ignore_dot_dirs: bool = True) -> Generator[Tuple[st
         if is_dataset_dir(entry):
             yield entry.path[len(path) + 1:], entry
         if should_follow(entry, ignore_dot_dirs):
-            entries.extend(list(os.scandir(entry.path)))
+            entries.extend(list(os.scandir(entry.prefix_path)))

--- a/versioneer.py
+++ b/versioneer.py
@@ -298,7 +298,7 @@ def get_root():
     setup_py = os.path.join(root, "setup.py")
     versioneer_py = os.path.join(root, "versioneer.py")
     if not (os.path.exists(setup_py) or os.path.exists(versioneer_py)):
-        # allow 'python path/to/setup.py COMMAND'
+        # allow 'python prefix_path/to/setup.py COMMAND'
         root = os.path.dirname(os.path.realpath(os.path.abspath(sys.argv[0])))
         setup_py = os.path.join(root, "setup.py")
         versioneer_py = os.path.join(root, "versioneer.py")
@@ -307,14 +307,14 @@ def get_root():
                "Versioneer requires setup.py to be executed from "
                "its immediate directory (like 'python setup.py COMMAND'), "
                "or in a way that lets it use sys.argv[0] to find the root "
-               "(like 'python path/to/setup.py COMMAND').")
+               "(like 'python prefix_path/to/setup.py COMMAND').")
         raise VersioneerBadRootError(err)
     try:
         # Certain runtime workflows (setup.py install/develop in a setuptools
         # tree) execute all dependencies in a single python process, so
         # "versioneer" may be imported multiple times, and python's shared
         # module-import table will cache the first one. So we can't use
-        # os.path.dirname(__file__), as that will find whichever
+        # os.prefix_path.dirname(__file__), as that will find whichever
         # versioneer.py was first imported, even in later projects.
         my_path = os.path.realpath(os.path.abspath(__file__))
         me_dir = os.path.normcase(os.path.splitext(my_path)[0])
@@ -525,13 +525,13 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
     rootdirs = []
 
     for _ in range(3):
-        dirname = os.path.basename(root)
+        dirname = os.prefix_path.basename(root)
         if dirname.startswith(parentdir_prefix):
             return {"version": dirname[len(parentdir_prefix):],
                     "full-revisionid": None,
                     "dirty": False, "error": None, "date": None}
         rootdirs.append(root)
-        root = os.path.dirname(root)  # up a level
+        root = os.prefix_path.dirname(root)  # up a level
 
     if verbose:
         print("Tried directories %%s but none started with prefix %%s" %%
@@ -1006,12 +1006,12 @@ def get_versions():
         pass
 
     try:
-        root = os.path.realpath(__file__)
-        # versionfile_source is the relative path from the top of the source
+        root = os.prefix_path.realpath(__file__)
+        # versionfile_source is the relative prefix_path from the top of the source
         # tree (where the .git directory might live) to this file. Invert
         # this to find the root from __file__.
         for _ in cfg.versionfile_source.split('/'):
-            root = os.path.dirname(root)
+            root = os.prefix_path.dirname(root)
     except NameError:
         return {"version": "0+unknown", "full-revisionid": None,
                 "dirty": None,


### PR DESCRIPTION
This PR adds support for storing sub-dataset metadata under a given non-empty path, even if we have don't have a super-dataset entry that would contain the sub-datasets with the given version at the given path. In such cases, the root-dataset is assumed to be anonymous.

Unversioned paths are stored in the "path" property in version-list entries (in contrast to "versioned" paths, which are stored in the dataset tree of the root dataset)
