### PR TITLE
Factor out metadata root record retrival

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = datalad-metadata-model
-version = 0.3.0rc1
+version = 0.3.0rc2
 url = https://github.com/datalad/datalad-metadata-model
 author = The DataLad Team and Contributors
 author_email = team@datalad.org


### PR DESCRIPTION
This PR factors out the code that retrieves a metadata-root-record from a repository or creates it, if it does not yet exist.
This simplifies the implementation of more complex operations for example, the implementation of a cache in meta-add