### PR TITLE
Auto-create MRR with correct super/subset-ids

### DIFF
--- a/dataladmetadatamodel/common.py
+++ b/dataladmetadatamodel/common.py
@@ -82,6 +82,8 @@ def get_top_nodes_and_metadata_root_record(
         primary_data_version: str,
         prefix_path: MetadataPath,
         dataset_tree_path: MetadataPath,
+        sub_dataset_id: Optional[UUID],
+        sub_dataset_version: Optional[str],
         auto_create: Optional[bool] = False
 ) -> Tuple[Optional[TreeVersionList], Optional[UUIDSet], Optional[MetadataRootRecord]]:
 
@@ -120,6 +122,8 @@ def get_top_nodes_and_metadata_root_record(
         primary_data_version,
         prefix_path,
         dataset_tree_path,
+        sub_dataset_id,
+        sub_dataset_version,
         auto_create)
 
     return tree_version_list, uuid_set, metadata_root_record
@@ -132,6 +136,8 @@ def get_metadata_root_record_from_top_nodes(
         primary_data_version: str,
         prefix_path: MetadataPath,
         dataset_tree_path: MetadataPath,
+        sub_dataset_id: Optional[UUID],
+        sub_dataset_version: Optional[str],
         auto_create: Optional[bool] = False
 ) -> Optional[MetadataRootRecord]:
 
@@ -182,11 +188,20 @@ def get_metadata_root_record_from_top_nodes(
 
         dataset_level_metadata = Metadata()
         file_tree = FileTree()
-        metadata_root_record = MetadataRootRecord(
-            dataset_id,
-            primary_data_version,
-            dataset_level_metadata,
-            file_tree)
+        if dataset_tree_path != MetadataPath(""):
+            assert sub_dataset_id is not None
+            assert sub_dataset_version is not None
+            metadata_root_record = MetadataRootRecord(
+                sub_dataset_id,
+                sub_dataset_version,
+                dataset_level_metadata,
+                file_tree)
+        else:
+            metadata_root_record = MetadataRootRecord(
+                dataset_id,
+                primary_data_version,
+                dataset_level_metadata,
+                file_tree)
         dataset_tree.add_dataset(dataset_tree_path, metadata_root_record)
     else:
         metadata_root_record = dataset_tree.get_metadata_root_record(

--- a/dataladmetadatamodel/metadata.py
+++ b/dataladmetadatamodel/metadata.py
@@ -251,13 +251,16 @@ class Metadata(MappableObject):
 
     @property
     def extractors(self) -> Generator[str, None, None]:
+        self.ensure_mapped()
         yield from self.instance_sets.keys()
 
     @property
     def extractor_runs(self) -> Generator[Tuple[str, MetadataInstanceSet], None, None]:
+        self.ensure_mapped()
         yield from self.instance_sets.items()
 
     def extractor_runs_for_extractor(self, extractor_name: str) -> MetadataInstanceSet:
+        self.ensure_mapped()
         return self.instance_sets[extractor_name]
 
     def add_extractor_run(self,
@@ -268,6 +271,7 @@ class Metadata(MappableObject):
                           configuration: ExtractorConfiguration,
                           metadata_content: JSONObject):
 
+        self.ensure_mapped()
         self.touch()
 
         instance_set = self.instance_sets.get(

--- a/dataladmetadatamodel/metadatarootrecord.py
+++ b/dataladmetadatamodel/metadatarootrecord.py
@@ -53,6 +53,7 @@ class MetadataRootRecord(MappableObject):
         self._file_tree = None
 
     def set_file_tree(self, file_tree: FileTree):
+        self.ensure_mapped()
         self.touch()
         self._file_tree = file_tree
 
@@ -65,6 +66,7 @@ class MetadataRootRecord(MappableObject):
     file_tree = property(fget=get_file_tree, fset=set_file_tree)
 
     def set_dataset_level_metadata(self, dataset_level_metadata: Metadata):
+        self.ensure_mapped()
         self.touch()
         self.dataset_level_metadata = dataset_level_metadata
 

--- a/dataladmetadatamodel/uuidset.py
+++ b/dataladmetadatamodel/uuidset.py
@@ -33,6 +33,7 @@ class UUIDSet(MappableObject):
         self.uuid_set = dict()
 
     def uuids(self):
+        self.ensure_mapped()
         return self.uuid_set.keys()
 
     def set_version_list(self,
@@ -51,6 +52,7 @@ class UUIDSet(MappableObject):
         Get the version list for uuid. If it is not mapped yet,
         it will be mapped.
         """
+        self.ensure_mapped()
         return self.uuid_set[uuid].read_in()
 
     def unget_version_list(self, uuid):

--- a/dataladmetadatamodel/versionlist.py
+++ b/dataladmetadatamodel/versionlist.py
@@ -71,14 +71,17 @@ class VersionList(MappableObject):
     def _get_version_record(self,
                             primary_data_version: str,
                             prefix_path: MetadataPath) -> VersionRecord:
+        self.ensure_mapped()
         return self.version_set[primary_data_version][prefix_path]
 
     def _get_version_records(self,
                              primary_data_version: str
                              ) -> Iterable[VersionRecord]:
+        self.ensure_mapped()
         return self.version_set[primary_data_version].values()
 
     def _iterate_version_records(self) -> Generator:
+        self.ensure_mapped()
         yield from (
             (version, version_record)
             for version, prefixed_set in self.version_set.items()
@@ -91,11 +94,13 @@ class VersionList(MappableObject):
             self._iterate_version_records())
 
     def versions(self) -> Iterable:
+        self.ensure_mapped()
         yield from map(
             lambda vvr: vvr[0],
             self._iterate_version_records())
 
     def versions_and_prefix_paths(self) -> Iterable:
+        self.ensure_mapped()
         yield from map(
             lambda vvr: (vvr[0], vvr[1].prefix_path),
             self._iterate_version_records())
@@ -109,6 +114,7 @@ class VersionList(MappableObject):
         its timestamp and prefix_path for the given version.
         If it is not mapped yet, it will be mapped.
         """
+        self.ensure_mapped()
         version_record = self._get_version_record(
             primary_data_version,
             prefix_path)
@@ -126,6 +132,7 @@ class VersionList(MappableObject):
         timestamp and prefix paths for the given version.
         If they are not mapped yet, they will be mapped.
         """
+        self.ensure_mapped()
         for version_record in self._get_version_records(primary_data_version):
             version_record.element.read_in()
             yield (
@@ -139,6 +146,7 @@ class VersionList(MappableObject):
         """
         Get an iterable of all versions and their records
         """
+        self.ensure_mapped()
         yield from (
             (
                 version,
@@ -160,6 +168,7 @@ class VersionList(MappableObject):
         Existing references are deleted.
         The entry is marked as dirty.
         """
+        self.ensure_mapped()
         self.touch()
         if primary_data_version not in self.version_set:
             self.version_set[primary_data_version] = dict()
@@ -218,6 +227,7 @@ class TreeVersionList(VersionList):
                          prefix_path: MetadataPath,
                          ) -> Tuple[str, MetadataPath, DatasetTree]:
 
+        self.ensure_mapped()
         time_stamp, prefix_path, dataset_tree = super().get_versioned_element(
             primary_data_version,
             prefix_path)
@@ -228,6 +238,7 @@ class TreeVersionList(VersionList):
                           primary_data_version: str,
                           ) -> Iterable[Tuple[str, MetadataPath, DatasetTree]]:
 
+        self.ensure_mapped()
         return super().get_versioned_elements(primary_data_version)
 
     def set_dataset_tree(self,
@@ -237,8 +248,8 @@ class TreeVersionList(VersionList):
                          dataset_tree: DatasetTree,
                          ):
 
+        self.ensure_mapped()
         self.touch()
-
         return super().set_versioned_element(
             primary_data_version=primary_data_version,
             time_stamp=time_stamp,


### PR DESCRIPTION
When MRRs are created for a sub-dataset, they have to added to the dataset-tree of the super-dataset, but with the id and version of the sub-dataset. This is now supported.
