### PR TITLE
Fix appveyor tests on branches

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -45,8 +45,8 @@
 #     respective CI run configuration).
 
 
-# make repository clone cheap
-shallow_clone: true
+# do not clone repositories shallow because we use versioneer
+shallow_clone: false
 
 
 environment:

--- a/dataladmetadatamodel/__init__.py
+++ b/dataladmetadatamodel/__init__.py
@@ -27,5 +27,6 @@ def check_serialized_version(json_object: JSONObject):
             f"{version_string}")
 
 
-from . import _version
-__version__ = _version.get_versions()['version']
+from ._version import get_versions
+__version__ = get_versions()['version']
+del get_versions


### PR DESCRIPTION
This PR fixes faulty test setup in appveyor for branches. The reason for the faulty tests was that we use `versioneer` and clone the repository `shallow` in appveyor. `versioneer` can not pick up correct, i.e. PEP440, compliant python-wheel names from a shallow clone. The soluation was to not clone shallowly anymore

