### PR TITLE
Store MRR dataset level metadata reference in object references

### DIFF
--- a/dataladmetadatamodel/mapper/gitmapper/gitblobcache.py
+++ b/dataladmetadatamodel/mapper/gitmapper/gitblobcache.py
@@ -4,6 +4,7 @@ from tempfile import TemporaryDirectory
 from typing import (
     Dict,
     List,
+    Tuple,
     Union,
 )
 
@@ -27,7 +28,7 @@ class GitBlobCache:
 
         self.realm = realm
         self.maxsize = maxsize
-        self.cached_objects: List[Union[str, bytes]] = list()
+        self.cached_objects: List[Tuple[Union[str, bytes], str]] = list()
         self.flushed_objects: Dict[Union[str, bytes], str] = dict()
         self.temporary_directory = TemporaryDirectory()
         self.temp_dir_path = Path(self.temporary_directory.name)

--- a/dataladmetadatamodel/mapper/gitmapper/metadatamapper.py
+++ b/dataladmetadatamodel/mapper/gitmapper/metadatamapper.py
@@ -1,9 +1,6 @@
 from typing import Dict
 
-from dataladmetadatamodel.mapper.gitmapper.objectreference import (
-    GitReference,
-    add_blob_reference,
-)
+from dataladmetadatamodel.mapper.gitmapper.objectreference import add_blob_reference
 from dataladmetadatamodel.mapper.gitmapper.gitbackend.subprocess import (
     git_load_str,
     git_save_str,

--- a/dataladmetadatamodel/mapper/gitmapper/metadatarootrecordmapper.py
+++ b/dataladmetadatamodel/mapper/gitmapper/metadatarootrecordmapper.py
@@ -4,6 +4,7 @@ from dataladmetadatamodel.mapper.gitmapper.gitbackend.subprocess import (
     git_load_json,
     git_save_json,
 )
+from dataladmetadatamodel.mapper.gitmapper.objectreference import add_blob_reference
 from dataladmetadatamodel.mapper.mapper import Mapper
 from dataladmetadatamodel.mapper.reference import Reference
 
@@ -79,6 +80,7 @@ class MetadataRootRecordGitMapper(Mapper):
                 realm,
                 "git",
                 force_write)
+            add_blob_reference(dataset_level_metadata_reference.location)
 
         json_object = {
             Strings.DATASET_IDENTIFIER: str(mrr.dataset_identifier),

--- a/dataladmetadatamodel/mapper/gitmapper/tests/test_metadatarootrecordmapper.py
+++ b/dataladmetadatamodel/mapper/gitmapper/tests/test_metadatarootrecordmapper.py
@@ -3,6 +3,7 @@ from unittest import mock
 from uuid import UUID
 
 from dataladmetadatamodel.mapper.gitmapper.gitblobcache import hash_blob
+from dataladmetadatamodel.mapper.gitmapper.treeupdater import EntryType
 from dataladmetadatamodel.metadata import Metadata
 from dataladmetadatamodel.metadatapath import MetadataPath
 from dataladmetadatamodel.metadatarootrecord import MetadataRootRecord
@@ -33,6 +34,9 @@ default_paths = [
 class TestMetadataMapper(unittest.TestCase):
 
     def test_basic_unmapping(self):
+        from dataladmetadatamodel.mapper.gitmapper.objectreference import (
+            cached_object_references,
+        )
 
         file_tree = create_file_tree_with_metadata(default_paths, [
             Metadata()
@@ -88,6 +92,12 @@ class TestMetadataMapper(unittest.TestCase):
                         'location': location_3}
                 }
             )
+
+            # check for object references
+            assert (EntryType.File, location_1) in cached_object_references, \
+                "Dataset-level metadata reference not found in object cache"
+            assert (EntryType.Directory, location_3) in cached_object_references, \
+                "File-level metadata tree reference not found in object cache"
 
 
 if __name__ == '__main__':

--- a/dataladmetadatamodel/mapper/gitmapper/tests/test_objectreferences.py
+++ b/dataladmetadatamodel/mapper/gitmapper/tests/test_objectreferences.py
@@ -8,11 +8,6 @@ from typing import (
     Tuple,
 )
 
-from nose.tools import (
-    assert_false,
-    assert_in,
-)
-
 from ..utils import create_git_repo
 
 from ..gitbackend.subprocess import (
@@ -111,10 +106,8 @@ def test_old_reference_conversion():
 
         # Check that the new references exist.
         for i in range(100, 300):
-            assert_in(_create_hash(i), references)
+            assert _create_hash(i) in references
 
         # Check that the old references are gone by trying to update them
-        assert_false(_does_ref_exist(realm, GitReference.LEGACY_BLOBS.value))
-        assert_false(_does_ref_exist(realm, GitReference.LEGACY_TREES.value))
-
-
+        assert _does_ref_exist(realm, GitReference.LEGACY_BLOBS.value) is False
+        assert _does_ref_exist(realm, GitReference.LEGACY_TREES.value) is False

--- a/dataladmetadatamodel/mapper/gitmapper/tests/test_treeupdater.py
+++ b/dataladmetadatamodel/mapper/gitmapper/tests/test_treeupdater.py
@@ -3,11 +3,6 @@ from collections import defaultdict
 from pathlib import Path
 from unittest.mock import patch
 
-from nose.tools import (
-    assert_equal,
-    assert_in,
-)
-
 from ..utils import create_git_repo
 from ..gitbackend.subprocess import (
     git_ls_tree,
@@ -53,10 +48,7 @@ def test_basic():
 
         lines = git_ls_tree_recursive(str(repo_path), result)
         for path_info in path_infos:
-            assert_in(
-                f"100644 blob {path_info.object_hash}\t{'/'.join(path_info.elements)}",
-                lines
-            )
+            assert f"100644 blob {path_info.object_hash}\t{'/'.join(path_info.elements)}" in lines
 
 
 def test_dir_adding():
@@ -76,10 +68,7 @@ def test_dir_adding():
 
         lines = git_ls_tree(str(repo_path), result)
         for path_info in path_infos:
-            assert_in(
-                f"040000 tree {path_info.object_hash}\t{'/'.join(path_info.elements)}",
-                lines
-            )
+            assert f"040000 tree {path_info.object_hash}\t{'/'.join(path_info.elements)}" in lines
 
 
 def test_dir_overwrite_error():
@@ -100,7 +89,7 @@ def test_dir_overwrite_error():
             add_paths(repo_path, path_infos, root_entries)
             raise RuntimeError("did not get expected ValueError")
         except ValueError as ve:
-            assert_equal(ve.args[0], "cannot convert Directory to File: a")
+            assert ve.args[0] == "cannot convert Directory to File: a"
 
 
 def test_file_overwrite_error():
@@ -121,9 +110,7 @@ def test_file_overwrite_error():
             add_paths(repo_path, path_infos, root_entries)
             raise RuntimeError("did not get expected ValueError")
         except ValueError as ve:
-            assert_equal(
-                ve.args[0],
-                "cannot convert File to Directory: LICENSE")
+            assert ve.args[0], "cannot convert File to Directory: LICENSE"
 
 
 def test_minimal_invocation():
@@ -206,6 +193,4 @@ def test_minimal_invocation():
 
         lines = git_ls_tree_recursive(str(repo_path), result)
         for path_info in path_infos:
-            assert_in(
-                f"100644 blob {path_info.object_hash}\t{'/'.join(path_info.elements)}",
-                lines)
+            assert f"100644 blob {path_info.object_hash}\t{'/'.join(path_info.elements)}" in lines

--- a/dataladmetadatamodel/mapper/gitmapper/versionlistmapper.py
+++ b/dataladmetadatamodel/mapper/gitmapper/versionlistmapper.py
@@ -1,9 +1,9 @@
-from dataladmetadatamodel.mapper.gitmapper.objectreference import GitReference
 from dataladmetadatamodel.mapper.gitmapper.gitbackend.subprocess import (
     git_load_json,
     git_save_json,
-    git_update_ref
+    git_update_ref,
 )
+from dataladmetadatamodel.mapper.gitmapper.objectreference import GitReference
 from dataladmetadatamodel.mapper.mapper import Mapper
 from dataladmetadatamodel.mapper.reference import Reference
 

--- a/dataladmetadatamodel/tests/test_remote.py
+++ b/dataladmetadatamodel/tests/test_remote.py
@@ -14,10 +14,13 @@ class TestRemote(unittest.TestCase):
             "git",
             "https://github.com/datalad/test_metadata"
         )
-        self.assertEqual(len(tree_version_list.version_set), 1)
-        self.assertEqual(len(uuid_set.uuid_set), 1)
+        self.assertEqual(len(tree_version_list.version_set), 2)
+        self.assertEqual(len(uuid_set.uuid_set), 2)
 
         for version, element_info in tree_version_list.versioned_elements:
+            # Ignore versions that are not known
+            if version == "73ad0039ade25bd0f6b0dbf9dd13006e3721cc38":
+                break
             time_stamp, dataset_path, dataset_tree = element_info
             dataset_tree = cast(DatasetTree, dataset_tree)
             dataset_tree.read_in()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 appdirs
-nose
 click
 dataclasses
 fasteners
 coverage
+pytest
+nose


### PR DESCRIPTION
Fixes #36 

This PR fixes issue #36. It ensures that dataset-level references in metadata root records are added to the object references tree. That ensures, that a fetch/push of the object reference tree will transport all metadata objects. 