### PR TITLE
Do not use external dataclasses on python version 3.8 and higher

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -62,10 +62,18 @@ environment:
     # List a CI run for each platform first, to have immediate access when there
     # is a need for debugging
 
-    # Ubuntu core tests
-    - ID: Ubu20
+    # Ubuntu core tests python 3.7
+    - ID: Ubu20P37
       DTS: dataladmetadatamodel
       APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
+      PY: 3.7
+      INSTALL_SYSPKGS: python3-virtualenv
+      CODECOV_PLATFORM: linux
+    # Ubuntu core tests python 3.8
+    - ID: Ubu20P37
+      DTS: dataladmetadatamodel
+      APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
+      PY: 3.8
       INSTALL_SYSPKGS: python3-virtualenv
       CODECOV_PLATFORM: linux
     # Windows core tests

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -70,7 +70,7 @@ environment:
       INSTALL_SYSPKGS: python3-virtualenv
       CODECOV_PLATFORM: linux
     # Ubuntu core tests python 3.8
-    - ID: Ubu20P37
+    - ID: Ubu20P38
       DTS: dataladmetadatamodel
       APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu2004
       PY: 3.8

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -143,7 +143,7 @@ install:
 
 
 build_script:
-  - python -m pip install -r requirements.txt
+  - python -m pip install -r requirements-devel.txt
   - python -m pip install .
 
 

--- a/.github/workflows/nosetests.yml
+++ b/.github/workflows/nosetests.yml
@@ -21,7 +21,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements-devel.txt
+          pip install .
           git config --global init.defaultBranch main
           git config --global user.email "test.action@example.com"
           git config --global user.name "Test Action"

--- a/.github/workflows/python-publish-dry-run.yml
+++ b/.github/workflows/python-publish-dry-run.yml
@@ -1,0 +1,33 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Dry-run Pypi package building
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build_package:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: python -m build

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -2,3 +2,6 @@ appdirs
 click
 dataclasses;python_version < '3.8'
 fasteners
+coverage
+nose
+pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,15 +14,16 @@ classifiers =
     Programming Language :: Python :: 3
 
 [options]
-python_requires = >= 3.6
+python_requires = >= 3.8
 install_requires =
     appdirs
     click
-    dataclasses
+    dataclasses;python_version < '3.8'
     fasteners
 test_requires =
-    nose
     coverage
+    nose
+    pytest
 packages = find:
 include_package_data = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ classifiers =
     Programming Language :: Python :: 3
 
 [options]
-python_requires = >= 3.8
+python_requires = >= 3.7
 install_requires =
     appdirs
     click

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     entry_points={
         "console_scripts": [
             "mdc=tools.metadata_creator.main:main"

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.7",
     entry_points={
         "console_scripts": [
             "mdc=tools.metadata_creator.main:main"


### PR DESCRIPTION
Fixes #40 

Change requirements to not include external dataclass-package, if the python version that is used is 3.8 or higher 