### PR TITLE
Remove dependency definitions from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,11 +38,5 @@ setuptools.setup(
         "console_scripts": [
             "mdc=tools.metadata_creator.main:main"
         ]
-    },
-    install_requires=[
-        "appdirs",
-        "click",
-        "dataclasses",
-        "fasteners"
-    ]
+    }
 )


### PR DESCRIPTION
This PR remove dependency definitions from `setup.py` and relies on the definitions in `setup.cfg`. This allows
to specify conditional installation of `dataclasses`, based on the python version.

This in turn allows us to skip installation of external `dataclasses` on python version 3.8 and higher, to prevent incompatiblity errors.