### PR TITLE
Lower the dataclass requirement to python < 3.7

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -1,6 +1,6 @@
 appdirs
 click
-dataclasses;python_version < '3.8'
+dataclasses;python_version < '3.7'
 fasteners
 coverage
 nose

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 appdirs
 click
-dataclasses;python_version < '3.8'
+dataclasses;python_version < '3.7'
 fasteners

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ python_requires = >= 3.7
 install_requires =
     appdirs
     click
-    dataclasses;python_version < '3.8'
     fasteners
 test_requires =
     coverage


### PR DESCRIPTION
external dataclasses-dependency is only required before python 3.7