### PR TITLE
Add file tree root to object references

### DIFF
--- a/dataladmetadatamodel/mapper/gitmapper/metadatamapper.py
+++ b/dataladmetadatamodel/mapper/gitmapper/metadatamapper.py
@@ -77,10 +77,12 @@ class MetadataGitMapper(Mapper):
         metadata_blob_location = git_save_str(realm, metadata.to_json())
         add_blob_reference(metadata_blob_location)
 
-        # Save reference. NB we don't have to save
-        # metadata_reference_blob_location to the
-        # reference objects because they will be
-        # reachable by a git tree entry.
+        # Save reference. NB we don't add the metadata reference to the object
+        # tree here. Our "owner" will do that if necessary. For example, the
+        # "MetadataRootRecord"-mapper will save the reference if it is used for
+        # dataset-level metadata. It will not save it, if it is used for
+        # file-level metadata, because that is reachable in a git-tree that is
+        # added to the object tree.
         metadata_reference_blob_location = git_save_str(
             realm,
             Reference(

--- a/dataladmetadatamodel/mapper/gitmapper/metadatarootrecordmapper.py
+++ b/dataladmetadatamodel/mapper/gitmapper/metadatarootrecordmapper.py
@@ -4,7 +4,10 @@ from dataladmetadatamodel.mapper.gitmapper.gitbackend.subprocess import (
     git_load_json,
     git_save_json,
 )
-from dataladmetadatamodel.mapper.gitmapper.objectreference import add_blob_reference
+from dataladmetadatamodel.mapper.gitmapper.objectreference import (
+    add_blob_reference,
+    add_tree_reference,
+)
 from dataladmetadatamodel.mapper.mapper import Mapper
 from dataladmetadatamodel.mapper.reference import Reference
 
@@ -72,6 +75,7 @@ class MetadataRootRecordGitMapper(Mapper):
                 realm,
                 "git",
                 force_write)
+            add_tree_reference(file_tree_reference.location)
 
         if mrr.dataset_level_metadata is None:
             dataset_level_metadata_reference = Reference.get_none_reference("Metadata")


### PR DESCRIPTION
Fixes issue #47 

This PR ensures that the file-tree root recorded in metadata root records is represented in the object tree
