### PR TITLE
Fix common functions

### DIFF
--- a/dataladmetadatamodel/common.py
+++ b/dataladmetadatamodel/common.py
@@ -115,16 +115,28 @@ def get_top_nodes_and_metadata_root_record(
     if uuid_set is None or tree_version_list is None:
         return None, None, None
 
-    metadata_root_record = get_metadata_root_record_from_top_nodes(
-        tree_version_list,
-        uuid_set,
-        dataset_id,
-        primary_data_version,
-        prefix_path,
-        dataset_tree_path,
-        sub_dataset_id,
-        sub_dataset_version,
-        auto_create)
+    if sub_dataset_id is not None:
+        metadata_root_record = get_metadata_root_record_from_top_nodes(
+            tree_version_list,
+            uuid_set,
+            sub_dataset_id,
+            sub_dataset_version,
+            prefix_path,
+            dataset_tree_path,
+            dataset_id,
+            primary_data_version,
+            auto_create)
+    else:
+        metadata_root_record = get_metadata_root_record_from_top_nodes(
+            tree_version_list,
+            uuid_set,
+            dataset_id,
+            primary_data_version,
+            prefix_path,
+            dataset_tree_path,
+            None,
+            None,
+            auto_create)
 
     return tree_version_list, uuid_set, metadata_root_record
 
@@ -136,26 +148,98 @@ def get_metadata_root_record_from_top_nodes(
         primary_data_version: str,
         prefix_path: MetadataPath,
         dataset_tree_path: MetadataPath,
-        sub_dataset_id: Optional[UUID],
-        sub_dataset_version: Optional[str],
+        root_dataset_id: Optional[UUID],
+        root_dataset_version: Optional[str],
         auto_create: Optional[bool] = False
 ) -> Optional[MetadataRootRecord]:
 
     """
-    The metadata root record for a given dataset id and a given dataset version.
+    Return a metadata root record for the dataset id `dataset_id` and the
+    dataset version `primary_data_version`. If `root_dataset_id` and
+    `root_dataset_version` or not `None`, and if `dataset_tree_path` is not
+    None, the metadata record will be in the dataset tree of the root dataset
+    version.
 
-    If auto_create is True, create the metadata root record with empty
-    dataset metadata and an empty file-tree connected to it.
+    If auto_create is True, create all necessary tree nodes and the metadata
+    root record with empty dataset metadata and an empty file-tree. It will
+    also add the datasets to the UUID set and the tree version list, if
+    necessary.
 
-    If auto_create is False and the metadata root record does not exist, None
+    If auto_create is False and the metadata root record does not exist None
     is returned.
 
-    If you want to preserve any changes, to the created metadata objects,
-    you have to save the returned objects (or their containers) and flush the
+    If you want to preserve any changes or any created metadata objects, you
+    have to save the returned objects (or their containers) and flush the
     realm.
     """
     if uuid_set is None or tree_version_list is None:
         return None
+
+    is_sub_dataset = dataset_tree_path != MetadataPath("")
+    if is_sub_dataset:
+        assert root_dataset_id is not None
+        assert root_dataset_version is not None
+
+    # If there is a root dataset id, make sure that the root dataset elements
+    # exist or return if `auto_create` is `False`.
+    if is_sub_dataset:
+        if root_dataset_id in uuid_set.uuids():
+            root_uuid_version_list = uuid_set.get_version_list(root_dataset_id)
+        else:
+            if auto_create is False:
+                return None
+            root_uuid_version_list = VersionList()
+            uuid_set.set_version_list(root_dataset_id, root_uuid_version_list)
+
+        if (root_dataset_version, prefix_path) in tree_version_list.versions_and_prefix_paths():
+            _, _, dataset_tree = tree_version_list.get_dataset_tree(
+                primary_data_version=root_dataset_version,
+                prefix_path=prefix_path)
+        else:
+            if auto_create is False:
+                return None
+            dataset_tree = DatasetTree()
+            tree_version_list.set_dataset_tree(
+                primary_data_version=root_dataset_version,
+                time_stamp=str(time.time()),
+                prefix_path=prefix_path,
+                dataset_tree=dataset_tree)
+
+        if MetadataPath("") not in dataset_tree:
+            if auto_create is False:
+                return None
+            root_mrr = MetadataRootRecord(
+                dataset_identifier=root_dataset_id,
+                dataset_version=root_dataset_version,
+                dataset_level_metadata=Metadata(),
+                file_tree=FileTree())
+            dataset_tree.add_dataset(MetadataPath(""), root_mrr)
+        else:
+            root_mrr = dataset_tree.get_metadata_root_record(
+                dataset_tree_path)
+
+        root_uuid_version_list.set_versioned_element(
+            primary_data_version=root_dataset_version,
+            time_stamp=str(time.time()),
+            prefix_path=prefix_path,
+            element=root_mrr)
+
+    else:
+
+        # Get the dataset tree
+        if (primary_data_version, prefix_path) in tree_version_list.versions_and_prefix_paths():
+            _, _, dataset_tree = tree_version_list.get_dataset_tree(
+                primary_data_version=primary_data_version,
+                prefix_path=prefix_path)
+        else:
+            if auto_create is False:
+                return None
+            dataset_tree = DatasetTree()
+            tree_version_list.set_dataset_tree(
+                primary_data_version=primary_data_version,
+                time_stamp=str(time.time()),
+                prefix_path=prefix_path,
+                dataset_tree=dataset_tree)
 
     if dataset_id in uuid_set.uuids():
         uuid_version_list = uuid_set.get_version_list(dataset_id)
@@ -165,43 +249,14 @@ def get_metadata_root_record_from_top_nodes(
         uuid_version_list = VersionList()
         uuid_set.set_version_list(dataset_id, uuid_version_list)
 
-    # Get the dataset tree
-    if (primary_data_version, prefix_path) in tree_version_list.versions_and_prefix_paths():
-        time_stamp, prefix_path, dataset_tree = \
-            tree_version_list.get_dataset_tree(primary_data_version, prefix_path)
-    else:
-        if auto_create is False:
-            return None
-        time_stamp = str(time.time())
-        dataset_tree = DatasetTree()
-        # TODO: set prefix_path
-        # TODO: distinguish between unversioned prefix_path and dataset tree prefix_path
-        tree_version_list.set_dataset_tree(
-            primary_data_version=primary_data_version,
-            time_stamp=time_stamp,
-            prefix_path=prefix_path,
-            dataset_tree=dataset_tree)
-
     if dataset_tree_path not in dataset_tree:
         if auto_create is False:
             return None
-
-        dataset_level_metadata = Metadata()
-        file_tree = FileTree()
-        if dataset_tree_path != MetadataPath(""):
-            assert sub_dataset_id is not None
-            assert sub_dataset_version is not None
-            metadata_root_record = MetadataRootRecord(
-                sub_dataset_id,
-                sub_dataset_version,
-                dataset_level_metadata,
-                file_tree)
-        else:
-            metadata_root_record = MetadataRootRecord(
-                dataset_id,
-                primary_data_version,
-                dataset_level_metadata,
-                file_tree)
+        metadata_root_record = MetadataRootRecord(
+            dataset_identifier=dataset_id,
+            dataset_version=primary_data_version,
+            dataset_level_metadata=Metadata(),
+            file_tree=FileTree())
         dataset_tree.add_dataset(dataset_tree_path, metadata_root_record)
     else:
         metadata_root_record = dataset_tree.get_metadata_root_record(

--- a/dataladmetadatamodel/common.py
+++ b/dataladmetadatamodel/common.py
@@ -215,15 +215,16 @@ def get_metadata_root_record_from_top_nodes(
                 file_tree=FileTree())
             dataset_tree.add_dataset(MetadataPath(""), root_mrr)
         else:
-            root_mrr = dataset_tree.get_metadata_root_record(
-                dataset_tree_path)
+            root_mrr = dataset_tree.get_metadata_root_record(MetadataPath(""))
 
-        root_uuid_version_list.set_versioned_element(
-            primary_data_version=root_dataset_version,
-            time_stamp=str(time.time()),
-            prefix_path=prefix_path,
-            element=root_mrr)
+        if (root_dataset_version, prefix_path) not in root_uuid_version_list.versions_and_prefix_paths():
+            root_uuid_version_list.set_versioned_element(
+                primary_data_version=root_dataset_version,
+                time_stamp=str(time.time()),
+                prefix_path=prefix_path,
+                element=root_mrr)
 
+        prefix_path = MetadataPath("")
     else:
 
         # Get the dataset tree
@@ -262,10 +263,11 @@ def get_metadata_root_record_from_top_nodes(
         metadata_root_record = dataset_tree.get_metadata_root_record(
             dataset_tree_path)
 
-    uuid_version_list.set_versioned_element(
-        primary_data_version,
-        str(time.time()),
-        dataset_tree_path,
-        metadata_root_record)
+    if (primary_data_version, prefix_path) not in uuid_version_list.versions_and_prefix_paths():
+        uuid_version_list.set_versioned_element(
+            primary_data_version,
+            str(time.time()),
+            dataset_tree_path,
+            metadata_root_record)
 
     return metadata_root_record

--- a/dataladmetadatamodel/common.py
+++ b/dataladmetadatamodel/common.py
@@ -265,9 +265,9 @@ def get_metadata_root_record_from_top_nodes(
 
     if (primary_data_version, prefix_path) not in uuid_version_list.versions_and_prefix_paths():
         uuid_version_list.set_versioned_element(
-            primary_data_version,
-            str(time.time()),
-            dataset_tree_path,
-            metadata_root_record)
+            primary_data_version=primary_data_version,
+            time_stamp=str(time.time()),
+            prefix_path=prefix_path,
+            element=metadata_root_record)
 
     return metadata_root_record


### PR DESCRIPTION
This PR fixes #52 

It fixes the code that auto_creates metadata root records and all related objects for either a single dataset or for a subdataset
