### PR TITLE
Allow multiple caching requests

### DIFF
--- a/dataladmetadatamodel/mapper/gitmapper/metadatamapper.py
+++ b/dataladmetadatamodel/mapper/gitmapper/metadatamapper.py
@@ -21,9 +21,8 @@ class MetadataGitMapper(Mapper):
 
     @classmethod
     def cache_realm(cls, realm: str):
-        if cls.get_cache(realm) is not None:
-            raise RuntimeError(f"already caching realm: {realm}")
-        cls.metadata_caches[realm] = GitBlobCache(realm)
+        if cls.get_cache(realm) is None:
+            cls.metadata_caches[realm] = GitBlobCache(realm)
 
     @classmethod
     def flush_realm(cls, realm: str):

--- a/dataladmetadatamodel/mapper/gitmapper/tests/test_metadatamapper.py
+++ b/dataladmetadatamodel/mapper/gitmapper/tests/test_metadatamapper.py
@@ -109,15 +109,6 @@ class TestMetadataMapper(unittest.TestCase):
                 json.loads(save_str.call_args_list[1][0][1]),
                 expected_reference_object)
 
-    def test_double_cache_detection(self):
-        metadata_mapper: MetadataGitMapper = cast(
-            MetadataGitMapper,
-            get_mapper("Metadata", "git")
-        )
-        metadata_mapper.cache_realm("a")
-        self.assertRaises(RuntimeError, metadata_mapper.cache_realm, "a")
-        self.assertRaises(RuntimeError, metadata_mapper.flush_realm, "err")
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR allows clients to request caching a realm multiple times. Only the first request will lead to a cache creation, the following requests will just be ignored.
