### PR TITLE
Fix metadatapath creation

### DIFF
--- a/dataladmetadatamodel/metadatapath.py
+++ b/dataladmetadatamodel/metadatapath.py
@@ -18,12 +18,11 @@ class MetadataPath(PurePosixPath):
                 cls,
                 "/".join(original_path.parts))
         else:
-            created_path = super().__new__(
-                cls,
-                "/".join(original_path.parts[1:]))
+            modified_path = "/".join(original_path.parts[1:])
+            created_path = super().__new__(cls, modified_path)
             logger.warning(
                 f"Denied creation of absolute metadata path: {original_path}, "
-                f"created {created_path} instead. This is considered an error "
+                f"created {modified_path} instead. This is considered an error "
                 f"in the calling code.")
 
         return created_path


### PR DESCRIPTION
The previous code hands a half-created MetadataPath-object to the `PurePosixPath.__str__`-method. This fails on Python 3.12
This PR fixes this situation